### PR TITLE
fix: orchestrator hardening (bugs 2233 + 2237 + 2238)

### DIFF
--- a/equipa/bash_security.py
+++ b/equipa/bash_security.py
@@ -1071,6 +1071,33 @@ def _is_inside_safe_interpreter_arg(command: str, quote_open_idx: int) -> bool:
     return bool(_SAFE_SCRIPT_INTERPRETER_BEFORE_QUOTE_RE.search(prefix))
 
 
+# CLI tools whose markdown-body flag (``--body``/``-b``/``--message``/``-m``)
+# legitimately carries multi-line markdown including ``# Header`` lines. The
+# body is passed as a single quoted token, so ``#`` cannot hide an argument.
+# Pattern matches the immediate token-pair before the quote: ``<tool> ...
+# <flag>``. The ``...`` allows other intervening flags like ``--title "X"``
+# but the flag must be the last token before the quote.
+_MARKDOWN_BODY_FLAG_BEFORE_QUOTE_RE = re.compile(
+    r"(?:^|[\s;&|`(])"
+    r"(?:gh|git|hub)\b"
+    r"[^|;&`(]*?"
+    r"\s(?:--body|-b|--message|-m)\s*$"
+)
+
+
+def _is_inside_markdown_body_arg(command: str, quote_open_idx: int) -> bool:
+    """Return True if the quote at ``quote_open_idx`` opens the body of a
+    markdown-accepting CLI flag (``gh pr create --body "..."``,
+    ``git commit -m "..."``, etc.). Inside such a body, ``\\n#`` is a
+    markdown header, not shell-comment smuggling — the body is one token to
+    the tool.
+    """
+    if quote_open_idx <= 0:
+        return False
+    prefix = command[:quote_open_idx]
+    return bool(_MARKDOWN_BODY_FLAG_BEFORE_QUOTE_RE.search(prefix))
+
+
 def _check_quoted_newline_comment(command: str) -> BashSecurityResult:
     """Check 23: Newline inside quotes where next line starts with #.
 
@@ -1080,12 +1107,21 @@ def _check_quoted_newline_comment(command: str) -> BashSecurityResult:
     standard Python comment syntax; agents writing Python heredocs hit this
     constantly (tasks #2075, #2077, #2096).
 
-    Loosen by allowlisting the ``-c``/``-e`` argument of script
-    interpreters whose body is NOT re-parsed by the shell: python, perl,
-    ruby, node. The check still fires for shells (``bash -c``,
-    ``sh -c``, ``zsh -c``) where ``#`` is the comment-smuggling primitive
-    this check was designed to catch, and for any other context where a
-    quoted ``\\n# ...`` could hide arguments.
+    Loosen by allowlisting:
+    - The ``-c``/``-e`` argument of script interpreters whose body is NOT
+      re-parsed by the shell: python, perl, ruby, node.
+    - The markdown-body argument of CLI tools that accept multi-line
+      markdown payloads (``gh``/``git``/``hub`` with ``--body``/``-b``/
+      ``--message``/``-m``). Markdown headers (``# Heading``) on a fresh
+      line inside the body would otherwise trip this check and kill PR
+      creation despite the agent having completed all code work — see
+      TheForge bug 2238. The body is a single quoted token to the tool, so
+      ``#`` cannot smuggle an argument.
+
+    The check still fires for shells (``bash -c``, ``sh -c``, ``zsh -c``)
+    where ``#`` is the comment-smuggling primitive this check was designed
+    to catch, and for any other context where a quoted ``\\n# ...`` could
+    hide arguments.
     """
     if "\n" not in command or "#" not in command:
         return _SAFE
@@ -1118,6 +1154,8 @@ def _check_quoted_newline_comment(command: str) -> BashSecurityResult:
             rest = command[i + 1:]
             if rest.lstrip().startswith("#"):
                 if _is_inside_safe_interpreter_arg(command, quote_open_idx):
+                    continue
+                if _is_inside_markdown_body_arg(command, quote_open_idx):
                     continue
                 return BashSecurityResult(
                     safe=False, check_id=CheckID.QUOTED_NEWLINE,

--- a/equipa/loops.py
+++ b/equipa/loops.py
@@ -796,6 +796,46 @@ async def _resolve_head_sha(
     return "HEAD"
 
 
+# Roles whose deliverable is a markdown report (audit/review), not code.
+# When these roles run and produce no code diff, the Tester phase has nothing
+# to test and would either spin in analysis paralysis or return tester_blocked.
+_AUDIT_ROLES = frozenset({"security-reviewer", "code-reviewer"})
+# Task types whose deliverable is documentation/analysis, not code.
+_AUDIT_TASK_TYPES = frozenset({"audit", "review"})
+
+
+def _is_audit_type_task(task: dict[str, Any] | None, task_role: str) -> bool:
+    """Return True if this task's deliverable is a markdown report, not code.
+
+    Triggers on either an audit-style ``task_type`` or one of the reviewer
+    roles. Matches the criteria spelled out in TheForge bug 2237.
+    """
+    if task_role in _AUDIT_ROLES:
+        return True
+    if not isinstance(task, dict):
+        return False
+    return (task.get("task_type") or "") in _AUDIT_TASK_TYPES
+
+
+async def _git_diff_is_empty(project_dir: str, base_ref: str = "HEAD") -> bool:
+    """Return True if there are no uncommitted code changes vs ``base_ref``.
+
+    Used to decide whether to skip the Tester phase on audit/review tasks.
+    On any failure (timeout, missing git), conservatively returns False so
+    the tester still runs — better a wasted tester cycle than a missed
+    real-code-change task.
+    """
+    try:
+        result = await git_run_async(
+            ["diff", base_ref], project_dir, timeout=10,
+        )
+        if result.returncode == 0:
+            return not result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, Exception):
+        pass
+    return False
+
+
 async def _capture_git_diff_context(
     project_dir: str,
     cycle: int,
@@ -1390,6 +1430,37 @@ async def run_dev_test_loop(
                     f"Loop warning: agent repeated same pattern "
                     f"{state.loop_detector.consecutive_same} times (cycle {cycle})"
                 )
+
+            # --- Audit/review short-circuit ---
+            # If this task's deliverable is a markdown report (audit, review,
+            # security-reviewer, code-reviewer) and there are no code changes,
+            # there is nothing for the tester to test. Running it anyway either
+            # wastes turns in analysis paralysis or returns tester_blocked when
+            # the diff is empty. See TheForge bug 2237.
+            if _is_audit_type_task(task, task_role):
+                diff_empty = await _git_diff_is_empty(project_dir, base_ref=prev_cycle_sha)
+                if diff_empty:
+                    md_files = [
+                        f for f in state.accumulated_files
+                        if f.lower().endswith(".md")
+                    ]
+                    if md_files:
+                        log(
+                            f"  [Cycle {cycle}] Tester skipped (audit-type task, "
+                            f"no code changes — developer wrote markdown deliverable: "
+                            f"{', '.join(md_files[:3])}).",
+                            output,
+                        )
+                        clear_checkpoints(task_id)
+                        _apply_cost_totals(dev_result, state.total_cost, state.total_duration)
+                        return dev_result, cycle, "tests_passed"
+                    log(
+                        f"  [Cycle {cycle}] Tester skipped (audit-type task, "
+                        f"no code changes and no markdown deliverable produced).",
+                        output,
+                    )
+                    _apply_cost_totals(dev_result, state.total_cost, state.total_duration)
+                    return dev_result, cycle, "failed"
 
             # --- Tester Phase ---
             log(f"\n  [Cycle {cycle}] Running Tester agent "

--- a/equipa/tasks.py
+++ b/equipa/tasks.py
@@ -19,7 +19,7 @@ from equipa.constants import (
     PROJECT_DIRS,
     THEFORGE_DB,
 )
-from equipa.db import db_conn
+from equipa.db import db_conn, get_db_connection
 
 # Ordered weakest -> strongest so we can compare/escalate complexities.
 _COMPLEXITY_RANK = {"simple": 0, "medium": 1, "complex": 2, "epic": 3}

--- a/tests/test_bash_security.py
+++ b/tests/test_bash_security.py
@@ -349,7 +349,48 @@ class TestQuotedNewline:
     """Check ID 23: Quoted newline + # comment hiding."""
 
     def test_quoted_newline_hash(self) -> None:
+        """Generic quoted newline + # in a non-allowlisted context still blocks."""
         result = check_bash_command('echo "hello\n# rm -rf /"')
+        assert not result.safe
+        assert result.check_id == CheckID.QUOTED_NEWLINE
+
+    def test_gh_pr_create_with_markdown_header_body(self) -> None:
+        """Bug 2238: ``gh pr create --body`` with markdown headers must not
+        be rejected. This is the exact pattern that was killing PR creation
+        despite the agent having completed all code work."""
+        result = check_bash_command(
+            'gh pr create --title "X" --body '
+            '"**Bold**\n# Header line\n- bullet"'
+        )
+        assert result.safe, (
+            f"gh pr create with markdown headers in --body should pass; "
+            f"got check_id={result.check_id} msg={result.message}"
+        )
+
+    def test_git_commit_short_flag_with_markdown_header(self) -> None:
+        """``git commit -m`` with a multi-line body including a # header."""
+        result = check_bash_command(
+            'git commit -m "fix: thing\n# Heading inside body\nmore"'
+        )
+        assert result.safe, (
+            f"git commit -m with markdown headers should pass; "
+            f"got check_id={result.check_id} msg={result.message}"
+        )
+
+    def test_gh_short_body_flag_with_markdown_header(self) -> None:
+        """``gh pr create -b`` is the short form of ``--body``."""
+        result = check_bash_command(
+            'gh issue create -b "report\n# Steps\n- do thing"'
+        )
+        assert result.safe, (
+            f"gh -b with markdown headers should pass; "
+            f"got check_id={result.check_id} msg={result.message}"
+        )
+
+    def test_bash_c_with_quoted_hash_still_blocked(self) -> None:
+        """Regression: ``bash -c "x\\n# evil"`` is still the original threat
+        model and must still be blocked."""
+        result = check_bash_command('bash -c "real\n# evil"')
         assert not result.safe
         assert result.check_id == CheckID.QUOTED_NEWLINE
 


### PR DESCRIPTION
**Summary**

Bundles three orchestrator improvements:

- **fix(2233)** — `equipa/tasks.py` was calling `get_db_connection()` in `verify_task_updated()` without importing it. The orchestrator crashed with a NameError after every successful task completion (agent work and DB updates already pushed by then, but the post-task auto-commit/auto-cleanup never ran). Added the missing import from `equipa.db`.

- **fix(2237)** — Tester unconditionally fired on audit/review tasks (role `security-reviewer` / `code-reviewer`, or `task_type` audit/review) whose deliverable is a markdown report, not code. With no code diff to test the tester either spun in analysis paralysis (task 2235: 14 turns) or returned `tester_blocked` (tasks 2243/2244). Now: when the role/type indicates an audit and the post-dev git diff is empty, the tester is skipped. Outcome is `tests_passed` if the developer wrote at least one .md file, `failed` otherwise.

- **fix(2238)** — Bash-security check 23 (QUOTED_NEWLINE) was killing legitimate `gh pr create --body \"...\\n# Header...\"` calls because markdown headers inside the body argument matched the comment-smuggling pattern. Added a narrow allowlist: when the quote opens after `gh`/`git`/`hub` paired with `--body`/`-b`/`--message`/`-m`, the inside-quote `\\n#` pattern is allowed. Original threat model preserved for shells (`bash -c \"x\\n# evil\"` stays blocked).

**Test plan**

- [x] Full suite green: 1466 passed in 116s
- [x] New tests for 2238: gh pr create with markdown body passes; git commit -m with markdown headers passes; bash -c with quoted hash still blocks
- [x] verify_task_updated import resolves at module load
- [x] Each fix is its own commit