### PR TITLE
fix(2263): scan working tree for .md when FILES_CHANGED marker absent

### DIFF
--- a/equipa/loops.py
+++ b/equipa/loops.py
@@ -1444,6 +1444,30 @@ async def run_dev_test_loop(
                         f for f in state.accumulated_files
                         if f.lower().endswith(".md")
                     ]
+                    if not md_files:
+                        # Fallback: scan the working tree for markdown files the
+                        # agent wrote without emitting a FILES_CHANGED marker.
+                        # accumulated_files is only populated from those markers,
+                        # so one-shot review tasks that just write the file and
+                        # stop would otherwise be misreported as failed even
+                        # though the deliverable is on disk. See bug 2263.
+                        try:
+                            status_result = await git_run_async(
+                                ["status", "--porcelain"], project_dir, timeout=5,
+                            )
+                            if status_result.returncode == 0:
+                                md_files = [
+                                    line[3:].strip()
+                                    for line in status_result.stdout.splitlines()
+                                    if len(line) > 3
+                                    and line[3:].strip().lower().endswith(".md")
+                                ]
+                        except (subprocess.TimeoutExpired, OSError) as exc:
+                            log(
+                                f"  [Cycle {cycle}] git status fallback failed "
+                                f"while probing for markdown deliverable: {exc}",
+                                output,
+                            )
                     if md_files:
                         log(
                             f"  [Cycle {cycle}] Tester skipped (audit-type task, "


### PR DESCRIPTION
Closes the secondary issue uncovered by the bug 2237 verification smoke test (task 2262 in TheForge): the audit-task short-circuit decided tests_passed vs failed solely from state.accumulated_files (agent-marker driven), missing one-shot review tasks where the agent wrote a markdown deliverable but did not emit FILES_CHANGED.

**Fix:** when accumulated_files yields no .md, fall back to git status --porcelain to find untracked .md files. Wrapped in a narrow try/except (subprocess.TimeoutExpired, OSError) so a git failure logs and falls through cleanly rather than crashing — never masks an actual error.

**Diff:** equipa/loops.py +24/-0. No behaviour change when the marker-based path already finds a deliverable; only kicks in on the fall-through.

**Verified the bug 2237 fix already deployed:** the smoke test produced log line **Tester skipped (audit-type task, no code changes and no markdown deliverable produced)** — proving the new short-circuit code path was firing in production. The 2263 fix just makes the outcome reporting accurate when the agent doesnt emit FILES_CHANGED.

**Test plan:** AST parse + diff inspection. No existing audit-flow tests in the repo (would require fully mocking DevTestState plus subprocess plumbing), so no integration test added here.