### PR TITLE
fix(2282): extract autoresearch retry into shared helper for parallel mode

### DIFF
--- a/equipa/dispatch.py
+++ b/equipa/dispatch.py
@@ -286,6 +286,93 @@ async def cleanup_failed_attempt(
 
 # --- DB Scanning & Scoring ---
 
+
+
+async def run_dev_test_loop_with_autoresearch(
+    task: dict,
+    project_dir: str,
+    project_context: dict,
+    args,
+    config: dict,
+    output: list[str] | None = None,
+):
+    """Run run_dev_test_loop with autoresearch retry on failure.
+
+    Bug 2282: extracted from the inline pattern that lived only in
+    run_dispatch (single-task path). run_parallel_tasks did not have this
+    wrapper, so any failure in --tasks N,M,O dispatch was final. This
+    helper is the canonical retry entry point - both call sites use it.
+
+    Returns:
+        (result, cycles, outcome, loop_total_cost, loop_total_duration, task)
+
+    The caller adds loop_total_cost / loop_total_duration to its own
+    running totals (caller may track preflight + loop costs separately).
+    The task dict is returned because autoresearch may re-fetch it
+    between attempts to pick up reflection-injected context.
+    """
+    task_id = task["id"]
+    autoresearch_on = is_feature_enabled(config, "autoresearch")
+    max_retries = config.get("autoresearch_max_retries", 3) if autoresearch_on else 0
+    retry_count = 0
+    attempt_reflections: list[str] = []
+    loop_total_cost = 0.0
+    loop_total_duration = 0.0
+
+    while True:
+        result, cycles, outcome = await run_dev_test_loop(
+            task, project_dir, project_context, args, output=output,
+        )
+        loop_total_duration += result.get("duration", 0)
+        if result.get("cost"):
+            loop_total_cost += result["cost"]
+
+        # Success - break out of retry loop
+        if outcome in ("tests_passed", "no_tests", "early_completed_no_changes"):
+            break
+
+        # Capture reflection on failed attempt for cross-attempt memory
+        attempt_reflection = _build_dispatch_attempt_reflection(
+            retry_count + 1, outcome, cycles, result,
+        )
+        attempt_reflections.append(attempt_reflection)
+
+        # Not retriable or retries exhausted
+        if not autoresearch_on or retry_count >= max_retries:
+            if retry_count > 0:
+                log(
+                    f"  [Autoresearch] Exhausted {retry_count}/{max_retries} retries "
+                    f"for task #{task_id}. Final outcome: {outcome}",
+                    output,
+                )
+            break
+
+        retry_count += 1
+        log(
+            f"  [Autoresearch] Task #{task_id} failed ({outcome}). "
+            f"Retry {retry_count}/{max_retries}...",
+            output,
+        )
+
+        # Clean up failed git branch and reset task for next attempt.
+        await cleanup_failed_attempt(
+            task_id, project_dir, attempt_reflections, output,
+        )
+
+        # Re-fetch task to get clean state (with injected reflections)
+        refreshed = fetch_task(task_id)
+        if not refreshed:
+            log(
+                f"  [Autoresearch] Task #{task_id} disappeared from DB. "
+                f"Aborting retries.",
+                output,
+            )
+            break
+        task = refreshed
+
+    return result, cycles, outcome, loop_total_cost, loop_total_duration, task
+
+
 def scan_pending_work() -> list[dict]:
     """Query DB for all projects with todo tasks, grouped by priority.
 
@@ -524,53 +611,16 @@ async def run_project_tasks(
         )
 
         # --- Autoresearch retry loop with cross-attempt memory ---
-        autoresearch_on = is_feature_enabled(config, "autoresearch")
-        max_retries = config.get("autoresearch_max_retries", 3) if autoresearch_on else 0
-        retry_count = 0
-        attempt_reflections: list[str] = []
-
-        while True:
-            result, cycles, outcome = await run_dev_test_loop(
-                task, project_dir, project_context, task_args, output=output,
+        # Bug 2282: extracted into module-level helper so run_parallel_tasks
+        # can reuse the same retry semantics. Both code paths now share one
+        # canonical autoresearch wrapper.
+        result, cycles, outcome, _loop_cost, _loop_duration, task = (
+            await run_dev_test_loop_with_autoresearch(
+                task, project_dir, project_context, task_args, config, output=output,
             )
-            total_duration += result.get("duration", 0)
-            if result.get("cost"):
-                total_cost += result["cost"]
-
-            # Success - break out of retry loop
-            if outcome in ("tests_passed", "no_tests", "early_completed_no_changes"):
-                break
-
-            # Extract reflection from failed attempt for cross-attempt memory
-            attempt_reflection = _build_dispatch_attempt_reflection(
-                retry_count + 1, outcome, cycles, result,
-            )
-            attempt_reflections.append(attempt_reflection)
-
-            # Not retriable or retries exhausted
-            if not autoresearch_on or retry_count >= max_retries:
-                if retry_count > 0:
-                    log(f"  [Autoresearch] Exhausted {retry_count}/{max_retries} retries "
-                        f"for task #{task_id}. Final outcome: {outcome}", output)
-                break
-
-            retry_count += 1
-            log(f"  [Autoresearch] Task #{task_id} failed ({outcome}). "
-                f"Retry {retry_count}/{max_retries}...", output)
-
-            # Clean up failed git branch and reset task for next attempt.
-            # cleanup_failed_attempt is now natively async (uses
-            # git_run_async under the hood), so it will not block the
-            # event loop while other parallel tasks are running.
-            await cleanup_failed_attempt(
-                task_id, project_dir, attempt_reflections, output,
-            )
-
-            # Re-fetch task to get clean state (with injected reflections)
-            task = fetch_task(task_id)
-            if not task:
-                log(f"  [Autoresearch] Task #{task_id} disappeared from DB. Aborting retries.", output)
-                break
+        )
+        total_cost += _loop_cost
+        total_duration += _loop_duration
 
         # Orchestrator-side DB update (don't rely on agent)
         update_task_status(task_id, outcome, output=output)
@@ -1416,8 +1466,16 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
                     logger.exception("[flows] child running update failed")
 
             log(f"\n[Task #{task['id']}] Starting: {task['title']}", output)
-            result, cycles, outcome = await run_dev_test_loop(
-                task, task_dir, project_context, args, output=output,
+            # Bug 2282 fix: parallel mode now gets the same autoresearch
+            # retry wrapper as single-task mode. Without this, BashSecurity
+            # false positives or analysis-paralysis early-terms in any of
+            # the N parallel tasks would be final with no reflection-
+            # injected retry. The helper is module-level above.
+            _config_for_loop = getattr(args, "dispatch_config", None) or {}
+            result, cycles, outcome, _, _, task = (
+                await run_dev_test_loop_with_autoresearch(
+                    task, task_dir, project_context, args, _config_for_loop, output=output,
+                )
             )
             update_task_status(task["id"], outcome, output=output)
             log(f"[Task #{task['id']}] Done: {outcome} ({cycles} cycles)", output)

--- a/tests/test_dispatch_autoresearch.py
+++ b/tests/test_dispatch_autoresearch.py
@@ -1,0 +1,175 @@
+"""Regression tests for bug 2282 — run_dev_test_loop_with_autoresearch.
+
+Bug 2282: parallel-mode --tasks N,M,O lost the autoresearch retry wrapper
+that single-task mode had. Fixed by extracting the retry pattern into a
+shared helper. These tests verify the helper retries on failure outcomes
+and stops on success outcomes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from equipa.dispatch import run_dev_test_loop_with_autoresearch
+
+
+def _make_args() -> MagicMock:
+    args = MagicMock()
+    args.dispatch_config = {}
+    return args
+
+
+@pytest.mark.asyncio
+async def test_returns_immediately_on_tests_passed():
+    """Success outcome breaks the retry loop on the first attempt."""
+    task = {"id": 1}
+    args = _make_args()
+    config = {"features": {"autoresearch": True}, "autoresearch_max_retries": 5}
+
+    with patch(
+        "equipa.dispatch.run_dev_test_loop",
+        AsyncMock(return_value=({"cost": 1.0, "duration": 10.0}, 1, "tests_passed")),
+    ) as mock_loop:
+        result, cycles, outcome, cost, duration, returned_task = (
+            await run_dev_test_loop_with_autoresearch(
+                task, "/tmp", {}, args, config,
+            )
+        )
+
+    assert outcome == "tests_passed"
+    assert cycles == 1
+    assert cost == 1.0
+    assert duration == 10.0
+    assert returned_task is task
+    mock_loop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_returns_immediately_on_no_tests():
+    """no_tests outcome is also success — no retry."""
+    task = {"id": 2}
+    args = _make_args()
+    config = {"features": {"autoresearch": True}, "autoresearch_max_retries": 5}
+
+    with patch(
+        "equipa.dispatch.run_dev_test_loop",
+        AsyncMock(return_value=({"cost": 0.5, "duration": 5.0}, 1, "no_tests")),
+    ) as mock_loop:
+        _, _, outcome, _, _, _ = await run_dev_test_loop_with_autoresearch(
+            task, "/tmp", {}, args, config,
+        )
+
+    assert outcome == "no_tests"
+    mock_loop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_autoresearch_disabled():
+    """If the feature flag is off, failure is final on the first attempt."""
+    task = {"id": 3}
+    args = _make_args()
+    config = {"features": {"autoresearch": False}, "autoresearch_max_retries": 5}
+
+    with patch(
+        "equipa.dispatch.run_dev_test_loop",
+        AsyncMock(return_value=({"cost": 0.0, "duration": 1.0}, 1, "early_terminated")),
+    ) as mock_loop:
+        _, _, outcome, _, _, _ = await run_dev_test_loop_with_autoresearch(
+            task, "/tmp", {}, args, config,
+        )
+
+    assert outcome == "early_terminated"
+    mock_loop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_retries_until_success():
+    """A failure followed by a success should result in 2 calls."""
+    task = {"id": 4}
+    args = _make_args()
+    config = {"features": {"autoresearch": True}, "autoresearch_max_retries": 5}
+
+    side_effect = [
+        ({"cost": 1.0, "duration": 5.0}, 1, "early_terminated"),
+        ({"cost": 1.0, "duration": 5.0}, 1, "tests_passed"),
+    ]
+
+    with patch(
+        "equipa.dispatch.run_dev_test_loop",
+        AsyncMock(side_effect=side_effect),
+    ) as mock_loop, patch(
+        "equipa.dispatch.cleanup_failed_attempt", AsyncMock()
+    ), patch(
+        "equipa.dispatch.fetch_task", return_value={"id": 4, "title": "x"}
+    ):
+        _, _, outcome, cost, duration, _ = await run_dev_test_loop_with_autoresearch(
+            task, "/tmp", {}, args, config,
+        )
+
+    assert outcome == "tests_passed"
+    # Costs accumulate across attempts
+    assert cost == 2.0
+    assert duration == 10.0
+    assert mock_loop.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retries_exhausted():
+    """If every retry fails, the helper returns the final failed outcome."""
+    task = {"id": 5}
+    args = _make_args()
+    config = {"features": {"autoresearch": True}, "autoresearch_max_retries": 2}
+
+    side_effect = [
+        ({"cost": 1.0, "duration": 5.0}, 1, "early_terminated"),
+        ({"cost": 1.0, "duration": 5.0}, 1, "early_terminated"),
+        ({"cost": 1.0, "duration": 5.0}, 1, "early_terminated"),
+    ]
+
+    with patch(
+        "equipa.dispatch.run_dev_test_loop",
+        AsyncMock(side_effect=side_effect),
+    ) as mock_loop, patch(
+        "equipa.dispatch.cleanup_failed_attempt", AsyncMock()
+    ), patch(
+        "equipa.dispatch.fetch_task", return_value={"id": 5, "title": "x"}
+    ):
+        _, _, outcome, _, _, _ = await run_dev_test_loop_with_autoresearch(
+            task, "/tmp", {}, args, config,
+        )
+
+    assert outcome == "early_terminated"
+    # max_retries=2 means 3 total attempts (initial + 2 retries)
+    assert mock_loop.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_aborts_if_task_disappears():
+    """If fetch_task returns None mid-retry, abort cleanly."""
+    task = {"id": 6}
+    args = _make_args()
+    config = {"features": {"autoresearch": True}, "autoresearch_max_retries": 5}
+
+    side_effect = [
+        ({"cost": 1.0, "duration": 5.0}, 1, "early_terminated"),
+        # fetch_task returning None should abort before this is reached
+        ({"cost": 1.0, "duration": 5.0}, 1, "tests_passed"),
+    ]
+
+    with patch(
+        "equipa.dispatch.run_dev_test_loop",
+        AsyncMock(side_effect=side_effect),
+    ) as mock_loop, patch(
+        "equipa.dispatch.cleanup_failed_attempt", AsyncMock()
+    ), patch(
+        "equipa.dispatch.fetch_task", return_value=None
+    ):
+        _, _, outcome, _, _, _ = await run_dev_test_loop_with_autoresearch(
+            task, "/tmp", {}, args, config,
+        )
+
+    # First call returned early_terminated; abort prevents second call
+    assert outcome == "early_terminated"
+    assert mock_loop.call_count == 1


### PR DESCRIPTION
**Closes TheForge bug 2282 (CRITICAL).**

**Problem.** The autoresearch retry loop existed only in **run_dispatch** (the single-task code path used by **--task N**). **run_parallel_tasks** (the path used by **--tasks N,M,O**) called **run_dev_test_loop** directly with no retry wrapper. Any failure in parallel mode was final - no reflection-injected retry, no second attempt.

**Symptom.** Today (2026-05-10) all three tasks 2279/2280/2281 in the ForgeFarm project were dispatched as **--tasks 2279,2280,2281**. Each was killed by a different BashSecurity false positive (checks 7, 8, 9 - filed separately as bugs 2283/2284/2285). Each was marked **blocked** after a single dev-test cycle with no retry. ~1 wasted across three tasks that would have plausibly recovered with reflection-augmented context.

**Fix.** Extract the retry pattern into a module-level helper:

**run_dev_test_loop_with_autoresearch(task, project_dir, project_context, args, config, output) -> (result, cycles, outcome, loop_total_cost, loop_total_duration, task)**

Both call sites now use it:
- **run_dispatch** at line ~525 (single-task path)
- **run_parallel_tasks** at line ~1419 (parallel path)

The helper returns the loops total cost/duration so callers can add into their own running totals (preflight + loop), plus the (possibly refreshed) task dict so reflection-injected context from **cleanup_failed_attempt** flows through correctly.

**Diff stat:** equipa/dispatch.py +106/-48 (net +58 because the loop is now defined once and called twice). tests/test_dispatch_autoresearch.py +175 (new file).

**Test plan:**
- 6 new regression tests in **tests/test_dispatch_autoresearch.py** covering: success on first attempt (tests_passed + no_tests), no retry when feature disabled, retry until success, retries exhausted, abort when task disappears mid-retry. All 6 pass.
- Existing **pytest tests/** suite passes 1466 tests, no regressions.

**Deploy plan.** Merge here, then **git pull** on Equipa-prod (same flow as PRs #1 and #2 from earlier this session). Confirms the fix landed when the next parallel dispatch in TheForge survives a BashSecurity false-positive instead of being marked blocked.