### PR TITLE
fix(2285) BashSecurity check 9 heredoc not file redirection

### DIFF
--- a/equipa/bash_security.py
+++ b/equipa/bash_security.py
@@ -730,11 +730,20 @@ def _check_redirections(unquoted: str) -> BashSecurityResult:
       - 2>&1, 2>/dev/null, >/dev/null, 2>>*.log (existing)
       - > and >> targeting /tmp/, ./, or any relative path (no leading /)
       - >> appending to *.log anywhere
+      - ``<<DELIM`` / ``<<-DELIM`` / ``<<'DELIM'`` / ``<<\\DELIM`` heredoc
+        opener (delimiter introduces literal text, not a file path)
+      - ``<<<word`` here-string operator (literal data, not a file path)
 
     Explicit denylist (always blocks regardless of above):
       - /etc/, /usr/, /bin/, /sbin/, /boot/, /root/, /sys/, /dev/sd*,
         /dev/disk*, /var/log/ (system logs), ~/.* (dotfile in home),
         /home/*/.* (dotfile in any user home)
+
+    Bug #2285 (task #2309): a bare ``<`` inside ``<<`` or ``<<<`` was being
+    treated as input redirection, blocking canonical heredoc and here-string
+    patterns (``cat <<EOF`` / ``cat <<<"$VAR"``). Strip the ``<<`` and ``<<<``
+    operators *before* the literal-char check so only a true bare ``<``
+    (file redirection) trips the block.
     """
     # Hard denylist applied to the ORIGINAL unquoted string before any
     # stripping — these targets are never safe even if they textually match
@@ -755,6 +764,11 @@ def _check_redirections(unquoted: str) -> BashSecurityResult:
 
     # Strip safe stderr/stdout redirection patterns before the literal-char check
     safe_patterns = [
+        # Heredoc / here-string operators MUST be stripped BEFORE bare-< check.
+        # Order matters: <<< (here-string) must be matched before << (heredoc)
+        # so the third < is not misread as a heredoc body word boundary.
+        r"<<<",                            # <<<word here-string operator
+        r"<<-?\s*\\?['\"]?[\w-]+['\"]?",   # <<EOF, <<-EOF, <<'EOF', <<\EOF
         r"2\s*>\s*&\s*1",                  # 2>&1
         r"2\s*>\s*/dev/null",              # 2>/dev/null
         r">\s*/dev/null",                  # >/dev/null

--- a/tests/test_bash_security.py
+++ b/tests/test_bash_security.py
@@ -189,6 +189,70 @@ class TestRedirection:
         assert not result.safe
         assert result.check_id == CheckID.OUTPUT_REDIRECTION
 
+    def test_heredoc_unquoted_delim_not_input_redirect(self) -> None:
+        """Bug #2285 (task #2309): ``<<EOF`` is a heredoc opener, not file
+        input redirection. The bare ``<`` of ``<<`` must not trigger check 9.
+
+        This standalone form (no ``$()`` wrapper) reaches check 9 because
+        the heredoc body is unquoted. Must be allowed through this check —
+        if anything blocks it, it must be a different check (e.g. 19).
+        """
+        result = check_bash_command("cat <<EOF\nhello\nEOF\n")
+        assert result.check_id != CheckID.INPUT_REDIRECTION, (
+            f"<<EOF heredoc opener must not be flagged as input "
+            f"redirection; got check_id={result.check_id} "
+            f"msg={result.message}"
+        )
+
+    def test_heredoc_quoted_delim_not_input_redirect(self) -> None:
+        """``<<'EOF'`` (single-quoted delimiter) heredoc must not fire
+        check 9. (Other checks like newline-detection may still fire on
+        a standalone multi-line command — this test only guards check 9.)"""
+        result = check_bash_command("cat <<'EOF'\nhello\nEOF\n")
+        assert result.check_id != CheckID.INPUT_REDIRECTION, (
+            f"<<'EOF' heredoc must not be flagged as input redirection; "
+            f"got check_id={result.check_id} msg={result.message}"
+        )
+
+    def test_heredoc_dash_delim_not_input_redirect(self) -> None:
+        """``<<-EOF`` (tab-stripping heredoc) must not fire check 9."""
+        result = check_bash_command("cat <<-EOF\n\thello\n\tEOF\n")
+        assert result.check_id != CheckID.INPUT_REDIRECTION
+
+    def test_heredoc_backslash_delim_not_input_redirect(self) -> None:
+        """``<<\\EOF`` (backslash-escaped delimiter) must not fire check 9."""
+        result = check_bash_command("cat <<\\EOF\nhello\nEOF\n")
+        assert result.check_id != CheckID.INPUT_REDIRECTION
+
+    def test_herestring_quoted_var(self) -> None:
+        """Bug #2285 (task #2309): ``<<<"$VAR"`` here-string must not be
+        flagged as input redirection."""
+        result = check_bash_command('cat <<<"$VAR"')
+        assert result.check_id != CheckID.INPUT_REDIRECTION, (
+            f"<<<\"$VAR\" here-string must not be flagged as input "
+            f"redirection; got check_id={result.check_id} "
+            f"msg={result.message}"
+        )
+
+    def test_herestring_literal_word(self) -> None:
+        """``cat <<<word`` here-string with literal word must not fire
+        check 9."""
+        result = check_bash_command("cat <<<word")
+        assert result.check_id != CheckID.INPUT_REDIRECTION
+
+    def test_input_redirect_still_blocks_after_heredoc_fix(self) -> None:
+        """Regression guard: the heredoc/here-string allowlist must NOT
+        let a true bare-``<`` file input redirection through."""
+        result = check_bash_command("cat < /etc/passwd")
+        assert not result.safe
+        assert result.check_id == CheckID.INPUT_REDIRECTION
+
+    def test_input_redirect_to_relative_file_still_blocks(self) -> None:
+        """``tee < input.txt`` is still file input redirection — blocks."""
+        result = check_bash_command("tee < input.txt")
+        assert not result.safe
+        assert result.check_id == CheckID.INPUT_REDIRECTION
+
 
 class TestDangerousVariables:
     """Check ID 6: Variables in redirect/pipe context."""


### PR DESCRIPTION
## Summary

Fixes BashSecurity check 9 false-positive where heredoc (`<<EOF`) and here-string (`<<<word`) operators were being treated as file input redirection. The bare `<` of `<<` / `<<<` was triggering the `INPUT_REDIRECTION` block, killing canonical heredoc/here-string usage.

## Root cause

In `equipa/bash_security.py::_check_redirections`, `safe_patterns` strips redirection patterns from the unquoted text and then checks whether a literal `<` remains. Heredoc and here-string operators were not in the strip list, so the first `<` of `<<` / `<<<` survived and tripped the bare-`<` check.

## Fix

Added two patterns to `safe_patterns` (ordered before `<` check):

- `r"<<<"` — strips here-string operator
- `r"<<-?\s*\\?['\"]?[\w-]+['\"]?"` — strips `<<EOF`, `<<-EOF`, `<<'EOF'`, `<<"EOF"`, `<<\EOF` heredoc openers

`<<<` is matched before `<<` so the third `<` is never misread.

## Behavior

| Pattern | Before | After |
|---|---|---|
| `cat <<EOF\nhello\nEOF` | BLOCKED (check 9) | not blocked by check 9 |
| `cat <<'EOF'\n...\nEOF` | BLOCKED (check 9) | not blocked by check 9 |
| `cat <<<"$VAR"` | BLOCKED (check 9) | not blocked by check 9 |
| `cat < /etc/passwd` | BLOCKED (check 9) | **STILL BLOCKED** (check 9) |
| `tee < input.txt` | BLOCKED (check 9) | **STILL BLOCKED** (check 9) |

## Test plan

- [x] `tests/test_bash_security.py::TestRedirection` — 11/11 pass (8 new tests)
- [x] Full `tests/test_bash_security.py` — 216/216 pass (no regressions)
- [x] `cat < /etc/passwd` still blocks as `INPUT_REDIRECTION`
- [x] `tee < input.txt` still blocks as `INPUT_REDIRECTION`
- [x] Existing `TestMultiLineCommitRegression` (heredoc-in-`$()` checks) still pass
