### PR TITLE
fix(2283) BashSecurity check 7 newlines in -c args

### DIFF
--- a/equipa/bash_security.py
+++ b/equipa/bash_security.py
@@ -821,38 +821,93 @@ def _check_dangerous_variables(unquoted: str) -> BashSecurityResult:
 
 
 def _check_newlines(command: str, unquoted: str) -> BashSecurityResult:
-    """Check 7: Newlines that could separate multiple commands."""
-    if not re.search(r"[\n\r]", unquoted):
+    """Check 7: Newlines that could separate multiple commands.
+
+    Only fires when the newline is at a true shell-token boundary —
+    i.e., OUTSIDE all quoted regions. Newlines embedded inside a quoted
+    argument to a script interpreter (``python3 -c "import x\\nimport y"``,
+    ``bash -c "set -e\\necho hi"``, ``psql -c "BEGIN;\\nSELECT 1;\\nCOMMIT;"``)
+    are consumed by the interpreter, not the shell, so they are NOT command
+    separators and must not trigger this check (the false-positive that
+    blocked agents writing multi-line script bodies through ``-c``/``-e``).
+
+    Walks the command character-by-character tracking quote state, so the
+    decision is made on real shell semantics rather than on the
+    ``_extract_unquoted`` helper's stripped output (which can desync when
+    quote nesting interacts with backslash escapes).
+
+    Carriage-return handling is preserved: ``\\r`` outside double quotes
+    is blocked because it can cause parser differentials between
+    shell-quote and bash.
+    """
+    if "\n" not in command and "\r" not in command:
         return _SAFE
-    # Newline/CR followed by non-whitespace (except \<newline> continuations)
-    if re.search(r"(?<![\s]\\)[\n\r]\s*\S", unquoted):
-        return BashSecurityResult(
-            safe=False, check_id=CheckID.NEWLINES,
-            message="Command contains newlines that could separate multiple commands",
-        )
-    # Carriage return outside double quotes
-    if "\r" in command:
-        in_single = False
-        in_double = False
-        esc = False
-        for ch in command:
-            if esc:
-                esc = False
+
+    in_single = False
+    in_double = False
+    escaped = False
+    quote_open_idx = -1
+
+    for i, ch in enumerate(command):
+        if escaped:
+            escaped = False
+            continue
+        if ch == "\\" and not in_single:
+            escaped = True
+            continue
+        if ch == "'" and not in_double:
+            if not in_single:
+                quote_open_idx = i
+            in_single = not in_single
+            continue
+        if ch == '"' and not in_single:
+            if not in_double:
+                quote_open_idx = i
+            in_double = not in_double
+            continue
+
+        if ch == "\n":
+            if in_single or in_double:
+                # Inside a quoted token — by shell semantics, NOT a
+                # command separator. Defense-in-depth: explicitly recognize
+                # the script-interpreter -c/-e case so the intent is
+                # documented and any future tightening here cannot
+                # accidentally re-introduce the false-positive.
+                if _is_inside_quoted_arg_value(command, quote_open_idx):
+                    continue
+                # Other quoted contexts: still part of the quoted token
+                # at the shell level, so the newline is not a separator.
+                # (Comment-smuggling via ``\n#`` is handled separately by
+                # check 23 / ``_check_quoted_newline_comment``.)
                 continue
-            if ch == "\\" and not in_single:
-                esc = True
+
+            # Unquoted newline — true shell-token boundary. Block only when
+            # followed by non-whitespace (i.e., a subsequent command on the
+            # next line), allowing ``\<NL>`` POSIX line continuations.
+            rest = command[i + 1:]
+            if not rest.lstrip():
                 continue
-            if ch == "'" and not in_double:
-                in_single = not in_single
+            j = i - 1
+            while j >= 0 and command[j] in " \t":
+                j -= 1
+            is_continuation = (
+                j >= 0
+                and command[j] == "\\"
+                and (j == 0 or command[j - 1] in (" ", "\t"))
+            )
+            if is_continuation:
                 continue
-            if ch == '"' and not in_single:
-                in_double = not in_double
-                continue
-            if ch == "\r" and not in_double:
-                return BashSecurityResult(
-                    safe=False, check_id=CheckID.NEWLINES,
-                    message="Command contains carriage return which can cause parser differentials",
-                )
+            return BashSecurityResult(
+                safe=False, check_id=CheckID.NEWLINES,
+                message="Command contains newlines that could separate multiple commands",
+            )
+
+        if ch == "\r" and not in_double:
+            return BashSecurityResult(
+                safe=False, check_id=CheckID.NEWLINES,
+                message="Command contains carriage return which can cause parser differentials",
+            )
+
     return _SAFE
 
 
@@ -1055,6 +1110,50 @@ _SAFE_SCRIPT_INTERPRETER_BEFORE_QUOTE_RE = re.compile(
     r"(?:python|python2|python3|py|perl|ruby|node|nodejs)"
     r"\s+-(?:c|e)\s*$"
 )
+
+
+# Broader allowlist used by check 7 (newlines): any interpreter or DB CLI
+# whose ``-c``/``-e``/``-x``/``--command`` argument is a multi-statement
+# script body where embedded newlines are legitimate (consumed by the
+# interpreter, not the shell). This includes shell interpreters
+# (``bash``/``sh``/``zsh``) — unlike the comment-smuggling check, a bare
+# newline inside ``bash -c "..."`` is NOT a shell-token boundary at the
+# outer shell level (the whole quoted body is ONE token to ``bash``).
+# The ``\n#`` smuggling primitive is still caught for shells by check 23
+# via ``_is_inside_safe_interpreter_arg`` (which intentionally excludes
+# the shells), so this looser list does not weaken that defense.
+_QUOTED_ARG_INTERPRETER_BEFORE_QUOTE_RE = re.compile(
+    r"(?:^|[\s;&|`(])"
+    r"(?:python|python2|python3|py|perl|ruby|node|nodejs|"
+    r"bash|sh|zsh|ksh|dash|fish|"
+    r"psql|mysql|mariadb|sqlite|sqlite3|"
+    r"awk|gawk|sed|"
+    r"php|lua|tclsh|R|Rscript)"
+    r"\s+-(?:c|e|x|-command)\s*$"
+)
+
+
+def _is_inside_quoted_arg_value(command: str, quote_open_idx: int) -> bool:
+    """Return True if the quote at ``quote_open_idx`` opens the body of a
+    script-interpreter or DB-CLI ``-c``/``-e`` argument where embedded
+    newlines are legitimate (``python3 -c``, ``bash -c``, ``psql -c``,
+    ``perl -e``, ``awk -e``, etc.).
+
+    Used by check 7 (``_check_newlines``) to ensure it only fires when the
+    newline is at a true shell-token boundary, not when it is inside a
+    quoted-string argument value being passed to a known interpreter. The
+    shell sees the whole quoted argument as one token, so newlines inside
+    are consumed by the interpreter — they cannot separate shell commands.
+
+    Mirrors ``_is_inside_safe_interpreter_arg`` (used by check 23) but
+    includes shell and DB CLIs because a newline alone is not the
+    comment-smuggling primitive — that primitive (``\\n#``) is what
+    check 23 catches with the narrower allowlist.
+    """
+    if quote_open_idx <= 0:
+        return False
+    prefix = command[:quote_open_idx]
+    return bool(_QUOTED_ARG_INTERPRETER_BEFORE_QUOTE_RE.search(prefix))
 
 
 def _is_inside_safe_interpreter_arg(command: str, quote_open_idx: int) -> bool:

--- a/tests/test_bash_security.py
+++ b/tests/test_bash_security.py
@@ -217,6 +217,48 @@ class TestNewlines:
         assert not result.safe
         assert result.check_id == CheckID.NEWLINES
 
+    def test_python_dash_c_with_embedded_newline_is_safe(self) -> None:
+        """python3 -c with newlines inside the quoted body is the legitimate
+        multi-statement script primitive — the shell sees the whole quoted
+        argument as one token. Bug 2307 regression."""
+        cmd = 'python3 -c "import struct\nimport sys\nprint(sys.version)"'
+        result = check_bash_command(cmd)
+        assert result.safe, f"False positive on python3 -c body: {result.message}"
+
+    def test_bash_dash_c_with_embedded_newline_is_safe(self) -> None:
+        """bash -c with newlines inside quotes is one shell token to the
+        outer shell. Comment-smuggling (\\n#) is still caught by check 23."""
+        cmd = 'bash -c "set -e\necho a\necho b"'
+        result = check_bash_command(cmd)
+        assert result.safe, f"False positive on bash -c body: {result.message}"
+
+    def test_psql_dash_c_with_embedded_newline_is_safe(self) -> None:
+        """psql -c with multi-statement SQL body must pass — SQL ; is not
+        a shell separator inside quotes."""
+        cmd = 'psql -c "BEGIN;\nSELECT 1;\nCOMMIT;"'
+        result = check_bash_command(cmd)
+        assert result.safe, f"False positive on psql -c body: {result.message}"
+
+    def test_perl_dash_e_with_embedded_newline_is_safe(self) -> None:
+        cmd = 'perl -e "use strict;\nprint 1;\n"'
+        result = check_bash_command(cmd)
+        assert result.safe, f"False positive on perl -e body: {result.message}"
+
+    def test_unquoted_newline_then_command_still_blocks(self) -> None:
+        """Defense-in-depth: a literal newline followed by another command
+        OUTSIDE any quotes must STILL be blocked."""
+        result = check_bash_command("echo hello\nrm -rf /")
+        assert not result.safe
+        assert result.check_id == CheckID.NEWLINES
+
+    def test_newline_after_closing_quote_still_blocks(self) -> None:
+        """Newline OUTSIDE the closing quote (after the -c body ends) is a
+        true shell-token boundary and must still block."""
+        cmd = 'python3 -c "print(1)"\nrm -rf /'
+        result = check_bash_command(cmd)
+        assert not result.safe
+        assert result.check_id == CheckID.NEWLINES
+
 
 class TestIFSInjection:
     """Check ID 11: $IFS / ${IFS} injection."""


### PR DESCRIPTION
## Summary

Tightens BashSecurity check 7 (newlines / parser differential) so it only fires when the newline is at a true shell-token boundary — i.e. OUTSIDE all quoted regions. A newline embedded inside a quoted argument to `python3 -c`, `bash -c`, `psql -c`, `perl -e`, etc. is NOT a shell command separator: the outer shell sees the whole quoted body as a single token, and the newline is consumed by the interpreter on the inside.

This was a high-impact false positive that has been blocking agents writing multi-line script bodies through `-c`/`-e` for several dispatches.

## Approach

- Replaces the regex-based `(?<![\s]\\)[\n\r]\s*\S` heuristic (which operates on the unquoted-stripped string and can desync) with an explicit character-by-character walk that tracks single/double-quote and backslash-escape state.
- Inside a quoted region, a `\n` is allowed unconditionally; the comment-smuggling primitive `\n#` is still caught for shells by the existing check 23 / `_is_inside_safe_interpreter_arg` (whose narrower allowlist excludes shells deliberately).
- Defense-in-depth: introduces `_is_inside_quoted_arg_value` mirroring the `_is_inside_safe_interpreter_arg` / `_is_inside_markdown_body_arg` pattern established by bug 2238, with a broader interpreter list (shells + DB CLIs + awk/sed/php/lua/...) since check 7's threat model is "command separation" rather than "comment smuggling".
- Carriage-return outside double quotes is preserved as a block.
- POSIX `\<NL>` line continuations remain allowed.

## Reproduction cases (all in `TestNewlines`)

| Input | Expected | Result |
|---|---|---|
| `python3 -c "import struct\nimport sys\nprint(...)"` | safe | PASS |
| `bash -c "set -e\necho a\necho b"` | safe | PASS |
| `psql -c "BEGIN;\nSELECT 1;\nCOMMIT;"` | safe | PASS |
| `perl -e "use strict;\nprint 1;\n"` | safe | PASS |
| `echo hello\nrm -rf /` (unquoted NL) | blocked | PASS |
| `python3 -c "print(1)"\nrm -rf /` (NL after closing quote) | blocked | PASS |

## Test plan

- [x] `pytest tests/test_bash_security.py::TestNewlines -v` — 8/8 pass (2 existing + 6 new)
- [x] `pytest tests/test_bash_security.py` — 214/214 pass, no regressions
- [ ] Smoke test on next dispatch that runs a `python3 -c` body that previously tripped check 7

## Commits

1. `fix(2283): tighten BashSecurity check 7 to only fire on true token boundaries` — implementation in `equipa/bash_security.py`
2. `test(2307): regression tests for check 7 quoted-arg newline allowlist` — 6 new pytest cases in `tests/test_bash_security.py::TestNewlines`

Closes the false-positive surfaced repeatedly during ForgeFarm Phase 1 and HelmBlade dispatches.
