### PR TITLE
fix(bash-security): allowlist git/gh/hg/jj/svn for check-4 locale-quoting (bug 2310)

### DIFF
--- a/equipa/bash_security.py
+++ b/equipa/bash_security.py
@@ -1308,11 +1308,18 @@ _ZSH_PRECOMMAND_MODIFIERS: frozenset[str] = frozenset([
 
 # Read-only text tools where locale quoting ($"...") is a legitimate i18n
 # pattern, not an attack vector. Allowlist used by Check 4.
+#
+# Also includes version-control / PR-creation commands (git/gh/hg/jj/svn)
+# where $"..." inside arguments is committed AS DATA into a commit message,
+# PR body, or changelog — it never reaches an exec context. The check-4
+# threat model (locale quoting as a vector to hide characters from exec)
+# does not apply here. See bug 2310.
 _LOCALE_QUOTING_SAFE_BASES: frozenset[str] = frozenset([
     "grep", "egrep", "fgrep", "rg", "ag", "ack",
     "sed", "awk", "gawk",
     "find", "fd",
     "echo", "printf",
+    "git", "gh", "hg", "jj", "svn",
 ])
 
 # Read-only commands safe to appear inside $() command substitution.

--- a/tests/test_bash_security.py
+++ b/tests/test_bash_security.py
@@ -956,6 +956,36 @@ class TestDeveloperLoosens:
         result = check_bash_command(cmd)
         assert not result.safe
 
+    # ---- Bug 2310: VCS / PR commands carry $"..." as DATA, not exec ---- #
+
+    def test_git_commit_with_locale_quoting_data_passes(self) -> None:
+        """`git commit -m "...$\"x\"..."` commits the bytes as a message;
+        the locale-quote sequence never reaches an exec context."""
+        cmd = 'git commit -m "fix: $\\"x\\" syntax"'
+        result = check_bash_command(cmd)
+        assert result.safe, f"expected safe: {cmd} -> {result.message}"
+
+    def test_gh_pr_create_with_locale_quoting_data_passes(self) -> None:
+        """`gh pr create` body containing $"..." is PR body text, not exec."""
+        cmd = 'gh pr create -t T -b "doc: $\\"y\\""'
+        result = check_bash_command(cmd)
+        assert result.safe, f"expected safe: {cmd} -> {result.message}"
+
+    def test_python_with_locale_quoting_still_blocks(self) -> None:
+        """`python -c $"..."` is an exec primitive — must remain blocked."""
+        result = check_bash_command(r'python -c $"echo"')
+        assert not result.safe
+
+    def test_eval_with_locale_quoting_still_blocks(self) -> None:
+        """`eval $"x"` evaluates locale-quoted content — must stay blocked."""
+        result = check_bash_command(r'eval $"x"')
+        assert not result.safe
+
+    def test_bash_c_with_locale_quoting_still_blocks(self) -> None:
+        """`bash -c $"x"` executes locale-quoted content — must stay blocked."""
+        result = check_bash_command(r'bash -c $"x"')
+        assert not result.safe
+
     # ---- Check 6: variables in pipes/redirects (loop counters) ---- #
 
     @pytest.mark.parametrize("cmd", [


### PR DESCRIPTION
**Closes TheForge bug 2310.**

Surgical fix: BashSecurity check 4 (locale-quoting `$"..."`) was blocking legitimate `git commit -m`, `gh pr create`, etc. when the message body contained the dollar-quote-quote sequence as data. The agent dispatch killed at turn 56 of forge-task-2280 was a real example.

## Why this is a false positive

The check-4 threat model is "locale quoting can hide characters from an exec primitive." The existing allowlist (`grep`, `sed`, `awk`, `find`, `echo`, `printf`) already exempts read-only text tools where locale quoting is a legitimate i18n use case. The same logic applies to VCS / PR-creation commands: `git commit`, `gh pr create`, `hg commit`, `jj describe`, `svn commit` all take their argument **as data** — the bytes are written to a commit object or PR body, never reaching `/bin/sh -c`.

## Diff

- `equipa/bash_security.py`: +7 lines — add `git`, `gh`, `hg`, `jj`, `svn` to `_LOCALE_QUOTING_SAFE_BASES`, with a comment block explaining the data-not-exec rationale.
- `tests/test_bash_security.py`: +30 lines — 5 regression tests:
  - `test_git_commit_with_locale_quoting_data_passes` — `git commit -m "fix: $\"x\""` PASSES
  - `test_gh_pr_create_with_locale_quoting_data_passes` — `gh pr create -b "doc: $\"y\""` PASSES
  - `test_python_with_locale_quoting_still_blocks` — `python -c $"echo"` STILL BLOCKED
  - `test_eval_with_locale_quoting_still_blocks` — `eval $"x"` STILL BLOCKED
  - `test_bash_c_with_locale_quoting_still_blocks` — `bash -c $"x"` STILL BLOCKED

37 net insertions, 0 deletions. Single allowlist data change.

## Security review

Conducted by EQUIPA's security-reviewer agent. Saved as `SECURITY-REVIEW-2310.md` in the project root.

- 0 CRITICAL, 0 HIGH, 0 MEDIUM, 0 LOW
- 3 INFO-level observations:
  - **S1**: pre-existing characteristic — the allowlist gates on `base_cmd` (first word), so `<allowed> ; <exec> $"..."` composed commands have always escaped the check. Not introduced by this PR; already true for `grep`/`sed`/etc. Track as separate hardening task if desired.
  - **S2**: a few esoteric `git -c core.editor=...` / `git filter-branch --msg-filter ...` configs do route through `/bin/sh -c`. Acceptable per the task rationale; could narrow to specific subcommands later.
  - **S3**: tests cover the stated cases but not composed forms — same scope as S1.
- **Conclusion: APPROVE.**

## Test plan

- [x] `python3 -m pytest tests/test_bash_security.py -q` → 213/213 pass (was 208 + 5 new)
- [x] `python3 -m pytest tests/test_bash_security.py -k locale_quoting -q` → 6/6 pass (5 new + 1 pre-existing)
- [ ] Reviewer: spot-check the diff against the rationale in the PR body and the SECURITY-REVIEW-2310.md file.

## Why this matters

After this lands and Equipa-prod pulls, EQUIPA agents will no longer trip on Go-source data containing locale-quote sequences when forming commit messages — closes the last known check-4 false positive that killed the ForgeFarm UI dispatch at turn 56.
