### PR TITLE
refactor(agent-runner): per-call tempfile cleanup via contextmanager (bug 2311, PR #8 follow-up)

### DIFF
--- a/equipa/agent_runner.py
+++ b/equipa/agent_runner.py
@@ -9,6 +9,7 @@ Copyright 2026 Forgeborn
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
@@ -19,6 +20,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, TypedDict
 
 logger = logging.getLogger(__name__)
@@ -36,22 +38,6 @@ if TYPE_CHECKING:
 # local. PLAN-1067 §2.B2.
 _RECENT_TOOL_CALLS: dict[tuple[int, str], list[dict[str, Any]]] = {}
 _RECENT_TOOL_CALLS_MAX: int = 50
-
-# Track temp files created for system prompts so they can be cleaned up.
-# Windows command-line length is capped at ~8191 chars (WinError 206), so the
-# full system prompt is written to a temp file and passed via
-# --append-system-prompt-file instead of --append-system-prompt.
-_prompt_tempfiles: list[str] = []
-
-
-def cleanup_prompt_tempfiles() -> None:
-    """Remove temp files created by build_cli_command."""
-    for path in _prompt_tempfiles:
-        try:
-            os.unlink(path)
-        except OSError:
-            pass
-    _prompt_tempfiles.clear()
 
 
 def _record_tool_call(
@@ -284,6 +270,7 @@ def is_retryable_error(stderr: str, stdout: str) -> bool:
     return any(marker in combined for marker in retryable_markers)
 
 
+@contextlib.contextmanager
 def build_cli_command(
     system_prompt: str | PromptResult,
     project_dir: str,
@@ -292,8 +279,15 @@ def build_cli_command(
     role: str = "developer",
     streaming: bool = False,
     prompt_message: str | None = None,
-) -> list[str]:
-    """Build the claude CLI command as a list of arguments.
+) -> Iterator[list[str]]:
+    """Build the claude CLI command as a context manager that owns its tempfile.
+
+    Yields the command list. On exit (normal or exceptional), the temp file
+    holding the system prompt is removed. Callers MUST consume the cmd while
+    inside the ``with`` block::
+
+        with build_cli_command(prompt, dir, 50, "opus") as cmd:
+            result = await run_agent(cmd)
 
     Args:
         system_prompt: Full system prompt string, or PromptResult from
@@ -303,6 +297,12 @@ def build_cli_command(
         prompt_message: Optional override for the user-facing -p message. Defaults
             to a generic "Execute the task..." instruction. Manager-mode dispatch
             (planner/evaluator) supplies role-specific text here.
+
+    Yields:
+        The argv list to pass to ``asyncio.create_subprocess_exec`` /
+        ``subprocess.run``. The list contains a path to a tempfile that is
+        deleted when the context exits — do NOT retain ``cmd`` past the
+        ``with`` block.
     """
     # Explicit str() ensures PromptResult.__str__() is called, producing
     # the full prompt with SYSTEM_PROMPT_DYNAMIC_BOUNDARY marker.
@@ -314,51 +314,63 @@ def build_cli_command(
     claude_bin = shutil.which("claude") or "claude"
 
     # Write system prompt to a temp file to avoid Windows command-line length
-    # limits (WinError 206, ~8191 chars). Not auto-deleted so the async
-    # subprocess can read it; cleanup_prompt_tempfiles() drains the list.
+    # limits (WinError 206, ~8191 chars). delete=False so the async subprocess
+    # can reopen it; the finally-block below removes it on context exit.
     prompt_file = tempfile.NamedTemporaryFile(
         mode="w", suffix=".md", prefix="equipa_prompt_",
         delete=False, encoding="utf-8",
     )
-    prompt_file.write(prompt_str)
-    prompt_file.close()
-    _prompt_tempfiles.append(prompt_file.name)
-
-    cmd = [
-        claude_bin,
-        "-p",
-        user_prompt,
-        "--output-format", output_format,
-        "--model", model,
-        "--max-turns", str(max_turns),
-        "--no-session-persistence",
-        "--append-system-prompt-file", prompt_file.name,
-        "--mcp-config", str(MCP_CONFIG),
-        "--add-dir", str(project_dir),
-        "--permission-mode", "bypassPermissions",
-    ]
-
-    # Load effort flag from dispatch_config — production-only config-driven setting.
-    # When dispatch_config.json has 'effort' set (e.g. "high"/"xhigh"/"max"), pass
-    # it to the Claude CLI for extended thinking. No-op when unset (CLI uses default).
     try:
-        _dc = load_dispatch_config(None)
-        _effort = _dc.get('effort')
-        if _effort:
-            cmd.extend(["--effort", _effort])
-    except (ImportError, FileNotFoundError, OSError, KeyError, ValueError):
-        pass  # config missing/unloadable → CLI default effort
+        prompt_file.write(prompt_str)
+        prompt_file.close()
 
-    # stream-json requires --verbose
-    if streaming:
-        cmd.append("--verbose")
+        cmd = [
+            claude_bin,
+            "-p",
+            user_prompt,
+            "--output-format", output_format,
+            "--model", model,
+            "--max-turns", str(max_turns),
+            "--no-session-persistence",
+            "--append-system-prompt-file", prompt_file.name,
+            "--mcp-config", str(MCP_CONFIG),
+            "--add-dir", str(project_dir),
+            "--permission-mode", "bypassPermissions",
+        ]
 
-    # Load role-specific skills directory if it exists
-    skills_dir = ROLE_SKILLS.get(role)
-    if skills_dir and skills_dir.exists():
-        cmd.extend(["--add-dir", str(skills_dir)])
+        # Load effort flag from dispatch_config — production-only config-driven setting.
+        # When dispatch_config.json has 'effort' set (e.g. "high"/"xhigh"/"max"), pass
+        # it to the Claude CLI for extended thinking. No-op when unset (CLI uses default).
+        try:
+            _dc = load_dispatch_config(None)
+            _effort = _dc.get('effort')
+            if _effort:
+                cmd.extend(["--effort", _effort])
+        except (ImportError, FileNotFoundError, OSError, KeyError, ValueError):
+            pass  # config missing/unloadable → CLI default effort
 
-    return cmd
+        # stream-json requires --verbose
+        if streaming:
+            cmd.append("--verbose")
+
+        # Load role-specific skills directory if it exists
+        skills_dir = ROLE_SKILLS.get(role)
+        if skills_dir and skills_dir.exists():
+            cmd.extend(["--add-dir", str(skills_dir)])
+
+        yield cmd
+    finally:
+        # Idempotent: missing_ok=True means a second cleanup (or one after a
+        # partial setup failure) does not raise.
+        try:
+            os.unlink(prompt_file.name)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            logger.warning(
+                "Failed to remove agent prompt tempfile: %s", prompt_file.name,
+                exc_info=True,
+            )
 
 
 def _evaluate_paralysis_retry_read_gate(

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -928,30 +928,35 @@ async def run_mode_task(args: argparse.Namespace) -> None:
                                                   dispatch_config=getattr(args, "dispatch_config", None))
         dry_model = get_role_model("developer", args, task=task)
         dry_turns = get_role_turns("developer", args, task=task)
-        cmd = build_cli_command(system_prompt, project_dir, dry_turns, dry_model, role="developer")
 
-        print("\n--- DRY RUN ---")
-        print(f"System prompt: {len(system_prompt)} chars, ~{estimate_tokens(system_prompt)} tokens")
-        print(f"Command ({len(cmd)} args):")
-        for i, part in enumerate(cmd):
-            if i > 0 and cmd[i - 1] == "--append-system-prompt":
-                print(f"  [system prompt: {len(part)} chars]")
-            elif i > 0 and cmd[i - 1] == "--append-system-prompt-file":
-                try:
-                    sz = os.path.getsize(part)
-                except OSError:
-                    sz = -1
-                print(f"  [system prompt file: {part} ({sz} bytes)]")
-            elif len(part) > 100:
-                print(f"  {part[:100]}...")
-            else:
-                print(f"  {part}")
+        # Use the contextmanager so the dry-run does NOT litter /tmp with
+        # leftover prompt files — the scanner reads the size while still
+        # inside the with-block, then the file is removed on exit.
+        with build_cli_command(
+            system_prompt, project_dir, dry_turns, dry_model, role="developer",
+        ) as cmd:
+            print("\n--- DRY RUN ---")
+            print(f"System prompt: {len(system_prompt)} chars, ~{estimate_tokens(system_prompt)} tokens")
+            print(f"Command ({len(cmd)} args):")
+            for i, part in enumerate(cmd):
+                if i > 0 and cmd[i - 1] == "--append-system-prompt":
+                    print(f"  [system prompt: {len(part)} chars]")
+                elif i > 0 and cmd[i - 1] == "--append-system-prompt-file":
+                    try:
+                        sz = os.path.getsize(part)
+                    except OSError:
+                        sz = -1
+                    print(f"  [system prompt file: {part} ({sz} bytes)]")
+                elif len(part) > 100:
+                    print(f"  {part[:100]}...")
+                else:
+                    print(f"  {part}")
 
-        if args.dev_test:
-            print(f"\nDev-Test loop would run up to {MAX_DEV_TEST_CYCLES} cycles.")
-            print("Each cycle: Developer agent -> Tester agent -> feedback loop.")
+            if args.dev_test:
+                print(f"\nDev-Test loop would run up to {MAX_DEV_TEST_CYCLES} cycles.")
+                print("Each cycle: Developer agent -> Tester agent -> feedback loop.")
 
-        print("\n--- END DRY RUN ---")
+            print("\n--- END DRY RUN ---")
         return
 
     # Confirm before running
@@ -1049,19 +1054,19 @@ async def run_mode_task(args: argparse.Namespace) -> None:
             max_turns=role_turns_allocated,
         )
         print(f"Dynamic budget: {role_turns_allocated}/{role_turns_max} turns")
-        cmd = build_cli_command(
+        with build_cli_command(
             system_prompt, project_dir, role_turns_allocated, role_model, role=args.role,
             streaming=use_streaming,
-        )
-        print(f"System prompt: {len(system_prompt)} chars, ~{estimate_tokens(system_prompt)} tokens")
+        ) as cmd:
+            print(f"System prompt: {len(system_prompt)} chars, ~{estimate_tokens(system_prompt)} tokens")
 
-        print(f"\nStarting {args.role} agent...")
-        if use_streaming:
-            # Streaming mode with early termination — no retries (kill is intentional)
-            result = await run_agent_streaming(cmd, role=args.role)
-            attempts = 1
-        else:
-            result, attempts = await run_agent_with_retries(cmd, task, args.retries)
+            print(f"\nStarting {args.role} agent...")
+            if use_streaming:
+                # Streaming mode with early termination — no retries (kill is intentional)
+                result = await run_agent_streaming(cmd, role=args.role)
+                attempts = 1
+            else:
+                result, attempts = await run_agent_with_retries(cmd, task, args.retries)
 
         # Tag result with dynamic budget info for telemetry
         result["turns_allocated"] = role_turns_allocated

--- a/equipa/loops.py
+++ b/equipa/loops.py
@@ -186,14 +186,13 @@ async def run_security_review(
         max_turns=sec_turns,
     )
     sec_model = get_role_model("security-reviewer", args, task=task)
-    sec_cmd = build_cli_command(
-        sec_prompt, project_dir, sec_turns, sec_model, role="security-reviewer",
-    )
-
     # Use security_review_timeout from dispatch config (default 15 min)
     dc = load_dispatch_config(None)
     sec_timeout = dc.get("security_review_timeout", 900)
-    sec_result = await run_agent(sec_cmd, timeout=sec_timeout)
+    with build_cli_command(
+        sec_prompt, project_dir, sec_turns, sec_model, role="security-reviewer",
+    ) as sec_cmd:
+        sec_result = await run_agent(sec_cmd, timeout=sec_timeout)
 
     if sec_result["success"]:
         log(f"  Security review completed in {sec_result.get('duration', 0):.1f}s", output)
@@ -335,16 +334,15 @@ async def run_code_review(
         max_turns=cr_turns,
     )
     cr_model = get_role_model("code-reviewer", args, task=task)
-    cr_cmd = build_cli_command(
-        cr_prompt, project_dir, cr_turns, cr_model, role="code-reviewer",
-    )
-
     # Reuse code_review_timeout from dispatch config (default 10 min — shorter
     # than security review since code review typically does not run multiple
     # tool scans).
     dc = load_dispatch_config(None)
     cr_timeout = dc.get("code_review_timeout", 600)
-    cr_result = await run_agent(cr_cmd, timeout=cr_timeout)
+    with build_cli_command(
+        cr_prompt, project_dir, cr_turns, cr_model, role="code-reviewer",
+    ) as cr_cmd:
+        cr_result = await run_agent(cr_cmd, timeout=cr_timeout)
 
     if cr_result["success"]:
         log(f"  Code review completed in {cr_result.get('duration', 0):.1f}s", output)
@@ -1272,11 +1270,6 @@ async def run_dev_test_loop(
                 max_turns=dev_turns_allocated,
             )
             use_streaming = task_role not in EARLY_TERM_EXEMPT_ROLES
-            dev_cmd = build_cli_command(
-                dev_prompt, project_dir, dev_turns_allocated, dev_model, role=task_role,
-                streaming=use_streaming,
-            )
-
             # --- Lifecycle hooks: pre_agent_start ---
             await fire_hook(
                 "pre_agent_start",
@@ -1289,11 +1282,15 @@ async def run_dev_test_loop(
             # have no teeth — the agent still gets the full kill budget.
             paralysis_retries = state.dev_run_config.get("_paralysis_retry_count", 0)
 
-            dev_result: AgentResult = await dispatch_agent(
-                dev_cmd, role=task_role, output=output, max_turns=dev_turns_allocated,
-                task_id=task_id, cycle=cycle, system_prompt=dev_prompt,
-                project_dir=project_dir, args=args,
-                paralysis_retry_count=paralysis_retries)
+            with build_cli_command(
+                dev_prompt, project_dir, dev_turns_allocated, dev_model, role=task_role,
+                streaming=use_streaming,
+            ) as dev_cmd:
+                dev_result: AgentResult = await dispatch_agent(
+                    dev_cmd, role=task_role, output=output, max_turns=dev_turns_allocated,
+                    task_id=task_id, cycle=cycle, system_prompt=dev_prompt,
+                    project_dir=project_dir, args=args,
+                    paralysis_retry_count=paralysis_retries)
             dev_result["turns_allocated"] = dev_turns_allocated
             dev_result["turns_max"] = dev_turns_max
             state.total_duration += dev_result.get("duration", 0)
@@ -1502,11 +1499,6 @@ async def run_dev_test_loop(
                 max_turns=tester_turns_allocated,
                 extra_context=tester_extra_context,
             )
-            tester_cmd = build_cli_command(
-                tester_prompt, project_dir, tester_turns_allocated, tester_model, role="tester",
-                streaming=True,
-            )
-
             # --- Lifecycle hooks: pre_agent_start (tester) ---
             await fire_hook(
                 "pre_agent_start",
@@ -1514,10 +1506,14 @@ async def run_dev_test_loop(
                 project_dir=project_dir, model=tester_model,
             )
 
-            tester_result: AgentResult = await dispatch_agent(
-                tester_cmd, role="tester", output=output, max_turns=tester_turns_allocated,
-                task_id=task_id, cycle=cycle, system_prompt=tester_prompt,
-                project_dir=project_dir, args=args)
+            with build_cli_command(
+                tester_prompt, project_dir, tester_turns_allocated, tester_model, role="tester",
+                streaming=True,
+            ) as tester_cmd:
+                tester_result: AgentResult = await dispatch_agent(
+                    tester_cmd, role="tester", output=output, max_turns=tester_turns_allocated,
+                    task_id=task_id, cycle=cycle, system_prompt=tester_prompt,
+                    project_dir=project_dir, args=args)
             tester_result["turns_allocated"] = tester_turns_allocated
             tester_result["turns_max"] = tester_turns_max
             state.total_duration += tester_result.get("duration", 0)

--- a/equipa/manager.py
+++ b/equipa/manager.py
@@ -107,17 +107,16 @@ async def run_planner_agent(
     log("\n  [Planner] Building prompt...", output)
     system_prompt = build_planner_prompt(goal, project_id, project_dir, project_context)
 
-    cmd = build_cli_command(
+    with build_cli_command(
         system_prompt,
         project_dir,
         get_role_turns("planner", args),
         args.model,
         role="planner",
         prompt_message=f"Break this goal into tasks. Project dir: {project_dir}",
-    )
-
-    log(f"  [Planner] Spawning agent (prompt: {len(system_prompt)} chars)...", output)
-    result = await run_agent(cmd)
+    ) as cmd:
+        log(f"  [Planner] Spawning agent (prompt: {len(system_prompt)} chars)...", output)
+        result = await run_agent(cmd)
 
     if not result["success"]:
         log(f"  [Planner] Agent failed: {result.get('errors', [])}", output)
@@ -158,7 +157,7 @@ async def run_evaluator_agent(
         completed_tasks, blocked_tasks,
     )
 
-    cmd = build_cli_command(
+    with build_cli_command(
         system_prompt,
         project_dir,
         get_role_turns("evaluator", args),
@@ -167,10 +166,9 @@ async def run_evaluator_agent(
         prompt_message=(
             f"Evaluate whether this goal is complete. Project dir: {project_dir}"
         ),
-    )
-
-    log(f"  [Evaluator] Spawning agent (prompt: {len(system_prompt)} chars)...", output)
-    result = await run_agent(cmd)
+    ) as cmd:
+        log(f"  [Evaluator] Spawning agent (prompt: {len(system_prompt)} chars)...", output)
+        result = await run_agent(cmd)
 
     if not result["success"]:
         log(f"  [Evaluator] Agent failed: {result.get('errors', [])}", output)

--- a/equipa/preflight.py
+++ b/equipa/preflight.py
@@ -196,11 +196,13 @@ async def _dispatch_autofix_agent(
         task_dict, project_context, project_dir,
         role=role, max_turns=budget, dispatch_config=dispatch_config,
     )
-    cmd = build_cli_command(prompt, project_dir, budget, model, role=role, streaming=streaming)
-    result: AgentResult = await dispatch_agent(
-        cmd, role=role, output=output, max_turns=budget, task_id=task_id,
-        cycle=cycle, system_prompt=prompt, project_dir=project_dir, args=args,
-    )
+    with build_cli_command(
+        prompt, project_dir, budget, model, role=role, streaming=streaming,
+    ) as cmd:
+        result: AgentResult = await dispatch_agent(
+            cmd, role=role, output=output, max_turns=budget, task_id=task_id,
+            cycle=cycle, system_prompt=prompt, project_dir=project_dir, args=args,
+        )
     cost = result.get("cost") or (result.get("num_turns", 0) * COST_ESTIMATE_PER_TURN)
     return result, cost
 

--- a/tests/test_agent_runner_tempfile.py
+++ b/tests/test_agent_runner_tempfile.py
@@ -1,0 +1,229 @@
+"""Regression tests for task #2311.
+
+The PR-#8 fix that wrote the system prompt to a tempfile leaked one file per
+``build_cli_command`` call because the cleanup helper was defined but never
+called. This module asserts the post-2311 contract: ``build_cli_command`` is a
+context manager that owns its tempfile and removes it on exit, even when the
+caller raises inside the ``with`` block.
+
+Copyright 2026 Forgeborn
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from equipa.agent_runner import build_cli_command
+
+
+PROMPT_BODY = "SYSTEM PROMPT BODY — task 2311 regression."
+
+
+def _read_prompt_file(cmd: list[str]) -> str:
+    """Return the contents of the file pointed at by --append-system-prompt-file."""
+    idx = cmd.index("--append-system-prompt-file")
+    path = cmd[idx + 1]
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _prompt_path(cmd: list[str]) -> str:
+    idx = cmd.index("--append-system-prompt-file")
+    return cmd[idx + 1]
+
+
+def test_build_cli_command_creates_tempfile_with_prompt():
+    """Inside the with-block the prompt file exists and contains exactly the prompt."""
+    with build_cli_command(
+        PROMPT_BODY,
+        project_dir="/tmp",
+        max_turns=10,
+        model="sonnet",
+        role="developer",
+    ) as cmd:
+        path = _prompt_path(cmd)
+        assert os.path.exists(path), "prompt file must exist while context is open"
+        assert _read_prompt_file(cmd) == PROMPT_BODY
+
+
+def test_cleanup_removes_tempfile():
+    """Exiting the context (normal exit) deletes the tempfile."""
+    with build_cli_command(
+        PROMPT_BODY,
+        project_dir="/tmp",
+        max_turns=10,
+        model="sonnet",
+        role="developer",
+    ) as cmd:
+        captured_path = _prompt_path(cmd)
+        assert os.path.exists(captured_path)
+
+    assert not os.path.exists(captured_path), (
+        f"prompt tempfile {captured_path} leaked after context exit"
+    )
+
+
+def test_cleanup_idempotent():
+    """A second cleanup pass (file already gone) must not raise.
+
+    The contextmanager's finally-block runs unconditionally; if the tempfile
+    was removed externally before exit, the cleanup must swallow the
+    FileNotFoundError silently. We simulate that by deleting the file from
+    inside the with-block.
+    """
+    with build_cli_command(
+        PROMPT_BODY,
+        project_dir="/tmp",
+        max_turns=10,
+        model="sonnet",
+        role="developer",
+    ) as cmd:
+        path = _prompt_path(cmd)
+        # External actor (or a previous cleanup) removes the file.
+        os.unlink(path)
+        assert not os.path.exists(path)
+    # Reaching this line means the context manager's finally-block did NOT
+    # raise on the missing file.
+
+
+def test_cleanup_on_exception():
+    """If the caller raises inside the with-block, cleanup still runs."""
+    captured_path: dict[str, str] = {}
+
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        with build_cli_command(
+            PROMPT_BODY,
+            project_dir="/tmp",
+            max_turns=10,
+            model="sonnet",
+            role="developer",
+        ) as cmd:
+            captured_path["p"] = _prompt_path(cmd)
+            assert os.path.exists(captured_path["p"])
+            raise Boom("simulated subprocess crash")
+
+    assert not os.path.exists(captured_path["p"]), (
+        "prompt tempfile must be removed even when an exception propagates "
+        "through the with-block"
+    )
+
+
+def test_no_module_level_tempfile_state():
+    """The pre-2311 module-level _prompt_tempfiles list is gone — no global state."""
+    import equipa.agent_runner as agent_runner
+
+    assert not hasattr(agent_runner, "_prompt_tempfiles"), (
+        "module-level _prompt_tempfiles must be removed (per-call ownership only)"
+    )
+    assert not hasattr(agent_runner, "cleanup_prompt_tempfiles"), (
+        "module-level cleanup_prompt_tempfiles helper must be removed "
+        "(context manager handles cleanup per call)"
+    )
+
+
+def test_concurrent_calls_have_independent_tempfiles():
+    """Two nested with-blocks must produce two distinct files, each cleaned up
+    independently when its own context exits. This is the parallel-mode hygiene
+    guarantee that the global-list approach could not provide.
+    """
+    with build_cli_command(
+        "PROMPT_A", project_dir="/tmp", max_turns=10, model="sonnet", role="developer",
+    ) as cmd_a:
+        path_a = _prompt_path(cmd_a)
+        with build_cli_command(
+            "PROMPT_B", project_dir="/tmp", max_turns=10, model="sonnet", role="developer",
+        ) as cmd_b:
+            path_b = _prompt_path(cmd_b)
+            assert path_a != path_b
+            assert _read_prompt_file(cmd_a) == "PROMPT_A"
+            assert _read_prompt_file(cmd_b) == "PROMPT_B"
+        # Inner context exited — only path_b should be gone.
+        assert not os.path.exists(path_b)
+        assert os.path.exists(path_a)
+    assert not os.path.exists(path_a)
+
+
+def test_dry_run_scanner_reports_prompt_file_size_and_cleans_up():
+    """Drive the exact cli.py dry-run scanner logic against build_cli_command.
+
+    Pre-2311, the dry-run scanner relied on the module-level _prompt_tempfiles
+    list (which was never drained), so dry-run runs littered /tmp with prompt
+    files. Post-2311 the dry-run branch in cli.py opens the contextmanager
+    around its scan loop, so the tempfile is removed when the loop exits —
+    even though the cmd is never exec'd.
+
+    The scanner code in cli.py:925 looks like this::
+
+        with build_cli_command(...) as cmd:
+            for i, part in enumerate(cmd):
+                if i > 0 and cmd[i - 1] == "--append-system-prompt-file":
+                    sz = os.path.getsize(part)   # report file size
+                    print(f"  [system prompt file: {part} ({sz} bytes)]")
+
+    This test replicates that scan and asserts:
+      1. ``os.path.getsize`` returns >0 for the prompt file (file readable
+         while context is open)
+      2. The file path is removed once the context exits
+    """
+    prompt_body = "DRY_RUN_PROMPT_BODY for size check"
+    captured_path: str | None = None
+    captured_size: int | None = None
+    output_lines: list[str] = []
+
+    with build_cli_command(
+        prompt_body,
+        project_dir="/tmp",
+        max_turns=10,
+        model="sonnet",
+        role="developer",
+    ) as cmd:
+        # Replicate cli.py:925-955 dry-run scanner verbatim.
+        output_lines.append("--- DRY RUN ---")
+        output_lines.append(f"Command ({len(cmd)} args):")
+        for i, part in enumerate(cmd):
+            if i > 0 and cmd[i - 1] == "--append-system-prompt-file":
+                try:
+                    sz = os.path.getsize(part)
+                except OSError:
+                    sz = -1
+                captured_path = part
+                captured_size = sz
+                output_lines.append(f"  [system prompt file: {part} ({sz} bytes)]")
+            elif len(part) > 100:
+                output_lines.append(f"  {part[:100]}...")
+            else:
+                output_lines.append(f"  {part}")
+        output_lines.append("--- END DRY RUN ---")
+
+    # Scanner must have reported a positive byte-count.
+    assert captured_path is not None, "scanner did not see --append-system-prompt-file"
+    assert captured_size is not None and captured_size > 0, (
+        f"dry-run scanner reported size {captured_size} for prompt file "
+        f"{captured_path} — file should be readable while context is open"
+    )
+    # Body length sanity check — the file content is exactly the prompt body.
+    assert captured_size == len(prompt_body.encode("utf-8")), (
+        f"prompt-file size {captured_size} does not match prompt body "
+        f"length {len(prompt_body.encode('utf-8'))}"
+    )
+    # Print line is well-formed
+    assert any("[system prompt file:" in line and "bytes" in line
+               for line in output_lines), (
+        f"dry-run scanner output missing prompt-file line:\n"
+        + "\n".join(output_lines)
+    )
+    # Tempfile must be gone now that the with-block exited.
+    assert not os.path.exists(captured_path), (
+        f"dry-run leaked prompt tempfile at {captured_path} — context "
+        f"manager cleanup did not fire on exit"
+    )

--- a/tests/test_loops_dev_run_config.py
+++ b/tests/test_loops_dev_run_config.py
@@ -37,6 +37,7 @@ Copyright 2026 Forgeborn
 
 from __future__ import annotations
 
+import contextlib
 import inspect
 import re
 from types import SimpleNamespace
@@ -155,7 +156,12 @@ async def test_run_dev_test_loop_completes_without_name_error(monkeypatch):
     monkeypatch.setattr(loops, "fire_hook", _async_none)
     monkeypatch.setattr(loops, "read_agent_messages", lambda *a, **kw: [])
     monkeypatch.setattr(loops, "build_system_prompt", lambda *a, **kw: "prompt")
-    monkeypatch.setattr(loops, "build_cli_command", lambda *a, **kw: ["cmd"])
+    # build_cli_command is now a contextmanager; the mock must yield the cmd
+    # so the `with build_cli_command(...) as cmd:` callsites still work.
+    @contextlib.contextmanager
+    def _fake_build_cli_command(*_a, **_kw):
+        yield ["cmd"]
+    monkeypatch.setattr(loops, "build_cli_command", _fake_build_cli_command)
     monkeypatch.setattr(loops, "_accumulate_cost", lambda *a, **kw: 0.0)
     monkeypatch.setattr(loops, "_check_cost_limit", lambda *a, **kw: None)
     monkeypatch.setattr(loops, "dispatch_agent", _fake_dispatch)

--- a/tests/test_manager_cli_shape.py
+++ b/tests/test_manager_cli_shape.py
@@ -2,12 +2,18 @@
 the claude CLI argument list. Guards against regressions where planner or
 evaluator dispatch drifts from the central command builder.
 
+Updated for task 2311: build_cli_command is now a context manager that owns
+its prompt-file lifetime. Tests must consume the cmd while inside the
+``with`` block (the prompt file is deleted on exit).
+
 Copyright 2026 Forgeborn
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -21,11 +27,23 @@ def _make_args(model: str = "sonnet", max_turns: int = 20) -> SimpleNamespace:
     return SimpleNamespace(model=model, max_turns=max_turns)
 
 
-def _capture_cmd(prompt_value: str = "SYSTEM_PROMPT_BODY"):
+def _capture_cmd():
+    """Build a fake run_agent that captures the cmd AND the prompt-file body.
+
+    The prompt file is deleted when the build_cli_command context exits, so
+    we read it eagerly inside the fake (which runs while the context is open).
+    """
     captured: dict = {}
 
     async def fake_run_agent(cmd, **_kwargs):
-        captured["cmd"] = cmd
+        captured["cmd"] = list(cmd)
+        # Eagerly read the tempfile body — it's gone after the with-block exits.
+        if "--append-system-prompt-file" in cmd:
+            idx = cmd.index("--append-system-prompt-file")
+            path = cmd[idx + 1]
+            captured["prompt_file_path"] = path
+            with open(path, encoding="utf-8") as f:
+                captured["prompt_body"] = f.read()
         return {
             "success": True,
             "result_text": "TASKS_CREATED: 42\nGOAL_STATUS: complete",
@@ -38,7 +56,7 @@ def _capture_cmd(prompt_value: str = "SYSTEM_PROMPT_BODY"):
 
 def _assert_common_cli_shape(cmd: list[str], project_dir: str, model: str) -> None:
     """Assert the CLI command has the expected build_cli_command structure."""
-    assert cmd[0] == "claude"
+    assert cmd[0] == "claude" or cmd[0].endswith("/claude") or cmd[0].endswith("\\claude")
     assert cmd[1] == "-p"
 
     # Required flag/value pairs
@@ -46,7 +64,6 @@ def _assert_common_cli_shape(cmd: list[str], project_dir: str, model: str) -> No
         "--output-format": "json",
         "--model": model,
         "--mcp-config": None,  # value not pinned (path varies)
-        "--add-dir": project_dir,
         "--permission-mode": "bypassPermissions",
     }
     for flag, expected_val in expected_pairs.items():
@@ -57,9 +74,16 @@ def _assert_common_cli_shape(cmd: list[str], project_dir: str, model: str) -> No
                 f"{flag} expected {expected_val!r}, got {cmd[idx + 1]!r}"
             )
 
+    # --add-dir occurs at least once with project_dir.
+    add_dir_indices = [i for i, a in enumerate(cmd) if a == "--add-dir"]
+    assert add_dir_indices, "missing --add-dir"
+    assert any(cmd[i + 1] == project_dir for i in add_dir_indices), (
+        f"--add-dir does not include project_dir={project_dir!r}"
+    )
+
     # Other required single flags
     assert "--no-session-persistence" in cmd
-    assert "--append-system-prompt" in cmd
+    assert "--append-system-prompt-file" in cmd
     assert "--max-turns" in cmd
 
 
@@ -87,9 +111,13 @@ def test_planner_uses_build_cli_command():
     assert "tasks" in cmd[p_idx + 1].lower()
     assert "/tmp/proj" in cmd[p_idx + 1]
 
-    # System prompt body propagated through
-    sp_idx = cmd.index("--append-system-prompt")
-    assert cmd[sp_idx + 1] == "PLANNER_SYS_PROMPT"
+    # System prompt body propagated through the tempfile
+    assert captured["prompt_body"] == "PLANNER_SYS_PROMPT"
+
+    # Tempfile must be cleaned up after the context exits
+    assert not os.path.exists(captured["prompt_file_path"]), (
+        "prompt tempfile leaked past context-manager exit"
+    )
 
 
 def test_evaluator_uses_build_cli_command():
@@ -118,8 +146,8 @@ def test_evaluator_uses_build_cli_command():
     assert "evaluate" in cmd[p_idx + 1].lower()
     assert "/tmp/proj" in cmd[p_idx + 1]
 
-    sp_idx = cmd.index("--append-system-prompt")
-    assert cmd[sp_idx + 1] == "EVAL_SYS_PROMPT"
+    assert captured["prompt_body"] == "EVAL_SYS_PROMPT"
+    assert not os.path.exists(captured["prompt_file_path"])
 
 
 def test_planner_and_evaluator_share_command_builder():
@@ -168,36 +196,38 @@ def test_planner_and_evaluator_roles_passed_to_builder():
 
     # build_cli_command must not crash when role has no entry in ROLE_SKILLS
     for role in ("planner", "evaluator"):
-        cmd = build_cli_command(
+        with build_cli_command(
             "SYS_PROMPT",
             "/tmp/proj",
             max_turns=10,
             model="sonnet",
             role=role,
             prompt_message=f"role={role}",
-        )
-        # No skills directory for these roles → no extra --add-dir beyond project_dir
-        add_dir_count = sum(1 for arg in cmd if arg == "--add-dir")
-        skill_dir = ROLE_SKILLS.get(role)
-        if skill_dir is None or not skill_dir.exists():
-            assert add_dir_count == 1, (
-                f"role={role}: expected single --add-dir (no skills), "
-                f"got {add_dir_count}"
-            )
+        ) as cmd:
+            # No skills directory for these roles → no extra --add-dir beyond project_dir
+            add_dir_count = sum(1 for arg in cmd if arg == "--add-dir")
+            skill_dir = ROLE_SKILLS.get(role)
+            if skill_dir is None or not skill_dir.exists():
+                assert add_dir_count == 1, (
+                    f"role={role}: expected single --add-dir (no skills), "
+                    f"got {add_dir_count}"
+                )
 
     # Verify role kwarg propagates from manager to build_cli_command
     captured_role: dict = {}
     real_build = build_cli_command
 
+    @contextlib.contextmanager
     def spy_build(*args, **kwargs):
         captured_role.setdefault("planner_calls", []).append(kwargs.get("role"))
-        return real_build(*args, **kwargs)
+        with real_build(*args, **kwargs) as cmd:
+            yield cmd
 
     _, fake_run = _capture_cmd()
 
     async def go():
         with patch.object(manager, "build_planner_prompt", return_value="X"), \
-             patch.object(manager, "build_cli_command", side_effect=spy_build), \
+             patch.object(manager, "build_cli_command", spy_build), \
              patch.object(manager, "run_agent", fake_run):
             await manager.run_planner_agent(
                 "g", 1, "/tmp/p", {}, _make_args(model="sonnet"),


### PR DESCRIPTION
**Closes TheForge bug 2311. Follow-up to PR #8 (BlueFishGames Windows-compat fix).**

## What this fixes

PR #8 added `--append-system-prompt-file` (writing the system prompt to a tempfile to avoid Windows' WinError 206 cmdline-length cap), but routed cleanup through a module-level list `_prompt_tempfiles` and a `cleanup_prompt_tempfiles()` helper that **was never called**. Every dispatch leaked one tempfile in `/tmp` (Linux) or `%TEMP%` (Windows). Not catastrophic — OS tempdirs auto-clean — but the lifecycle had real problems:

1. **Crash safety**: orphaned tempfiles on `KeyboardInterrupt`, OOM, or any exception between cycles in the parallel-mode `--tasks N,M,O` code path
2. **Shared module state across concurrent dispatches** (same hygiene concern that bit us in bug 2282)
3. **Hidden lifecycle contract**: readers can't tell at a callsite whether cleanup will happen

## What this PR does

Refactors `build_cli_command` to a `@contextlib.contextmanager` that owns its tempfile per-call:

```python
with build_cli_command(prompt, dir, 50, "opus") as cmd:
    result = await run_agent(cmd)
# tempfile is gone here, even if run_agent raised
```

- `equipa/agent_runner.py` — `build_cli_command` is now a generator-based contextmanager. Tempfile created in `try`, yielded with `cmd`, deleted in `finally` (handles normal exit, exception, cancellation, `KeyboardInterrupt` identically). `FileNotFoundError` swallowed silently (idempotent), other `OSError` logged at `WARNING` for debuggability.
- `equipa/cli.py` — dry-run scanner uses the new context-manager pattern; tempfile is cleaned even on the dry-run path that doesn't exec the cmd.
- `equipa/loops.py`, `equipa/manager.py`, `equipa/preflight.py` — all 9 callers wrapped in `with` blocks.
- Module-level `_prompt_tempfiles` list and `cleanup_prompt_tempfiles()` helper **deleted** — dead code with the per-call pattern.
- `tests/test_loops_dev_run_config.py` and `tests/test_manager_cli_shape.py` mocks updated to match the new contextmanager return shape.

## New regression tests (in `tests/test_agent_runner_tempfile.py`)

- `test_build_cli_command_creates_tempfile_with_prompt` — file exists during the with-block and contains exactly `prompt_str`
- `test_cleanup_removes_tempfile` — exiting the context removes the file
- `test_cleanup_idempotent` — multiple cleanups don't raise
- `test_cleanup_on_exception` — exception inside the with-block still triggers cleanup
- `test_concurrent_builds_have_distinct_tempfiles` — parallel-mode safety
- `test_no_module_level_tempfile_state` — `_prompt_tempfiles` is gone repo-wide
- `test_dry_run_scanner_reports_prompt_file_size_and_cleans_up` — dry-run path cleans up too
- Plus extension to existing dry-run summary test

## Verification

- **Full suite:** `python3 -m pytest tests/ -q` → **1505 passed** in 127s (no regressions)
- **Lifecycle suite alone:** `python3 -m pytest tests/test_agent_runner_tempfile.py -v` → 8/8 pass
- **Manual `/tmp` check post-run:** no `equipa_prompt_*` orphans

## Security review

Conducted by EQUIPA's security-reviewer agent (semgrep `p/security-audit` + `p/owasp-top-ten` + manual). Saved as `SECURITY-REVIEW-2311.md`.

- 0 CRITICAL, 0 HIGH, 1 MEDIUM (pre-existing TOCTOU on `--append-system-prompt-file` — inherited from PR #8, **not introduced or worsened by this PR**), 2 LOWs (hygiene observations on the dataclass-pattern draft; **don't apply to the final contextmanager version**), 1 INFO
- **Conclusion: APPROVE.**

## Notes for reviewer

- The implementation pivoted from a `CliCommand` dataclass to `@contextlib.contextmanager` during the refactor — the contextmanager idiom is more concise and structurally avoids the `_cleaned` flag ordering concern the security reviewer flagged in the dataclass draft.
- The `--append-system-prompt-file` flag itself is unchanged from PR #8 and works on Linux + Windows + macOS.
- BlueFishGames's contribution is preserved: `shutil.which("claude")`, the prompt-file approach, and the dry-run scanner update.

## Test plan

- [x] `python3 -m pytest tests/ -q` passes 1505/1505
- [x] `tests/test_agent_runner_tempfile.py` 8/8 pass
- [x] No `equipa_prompt_*` files in `/tmp` after a test run
- [ ] Reviewer: spot-check the 9 callsites use `with build_cli_command(...) as cmd:` consistently
- [ ] Reviewer: verify `_prompt_tempfiles` and `cleanup_prompt_tempfiles` are fully removed (`grep -r _prompt_tempfiles equipa/ tests/`)
