### PR TITLE
fix(dispatch): run security review in parallel-mode before merge (bug 2321)

### DIFF
--- a/equipa/dispatch.py
+++ b/equipa/dispatch.py
@@ -1515,6 +1515,42 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
                     task, task_dir, project_context, args, _config_for_loop, output=output,
                 )
             )
+
+            # Bug 2321: run security review in parallel-mode BEFORE marking
+            # the task done. Single-task mode runs review after dev-test
+            # success (cli.py:run_dispatch); parallel mode used to skip
+            # this step, so multi-task dispatches landed un-reviewed code
+            # on master. CRITICAL/HIGH findings demote the recorded outcome
+            # so update_task_status leaves the task as blocked (not done)
+            # and the post-gather merge skips this branch.
+            review_blocks_merge = False
+            review_counts: dict | None = None
+            if (
+                _is_security_review_enabled(args)
+                and outcome in ("tests_passed", "no_tests")
+            ):
+                try:
+                    await run_security_review(
+                        task, task_dir, project_context, args, output=output,
+                    )
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception(
+                        "[Task #%s] security review crashed", task["id"],
+                    )
+                review_blocks_merge, review_counts = (
+                    _security_review_blocks_merge(task_dir, task["id"])
+                )
+                if review_blocks_merge:
+                    log(
+                        f"[Task #{task['id']}] SECURITY GATE: blocking merge — "
+                        f"{review_counts.get('CRITICAL', 0)} CRITICAL, "
+                        f"{review_counts.get('HIGH', 0)} HIGH finding(s). "
+                        f"Branch forge-task-{task['id']} left unmerged for "
+                        f"operator review.",
+                        output,
+                    )
+                    outcome = "security_review_blocked"
+
             update_task_status(task["id"], outcome, output=output)
             log(f"[Task #{task['id']}] Done: {outcome} ({cycles} cycles)", output)
             if flow_id is not None:
@@ -1542,39 +1578,6 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
                 max_turns=get_role_turns(task_role, args, task=task),
                 cycle_number=cycles, output=output,
             )
-
-            # Bug 2321: run security review in parallel-mode BEFORE marking
-            # the task for merge. Single-task mode runs review after a
-            # successful dev-test (cli.py:run_dispatch); parallel mode used
-            # to skip this step entirely, so multi-task dispatches landed
-            # un-reviewed code on master. Review runs inside the worktree
-            # so the artifact is committed and travels with the merge.
-            review_blocks_merge = False
-            review_counts: dict | None = None
-            if (
-                _is_security_review_enabled(args)
-                and outcome in ("tests_passed", "no_tests")
-            ):
-                try:
-                    await run_security_review(
-                        task, task_dir, project_context, args, output=output,
-                    )
-                except Exception:  # pragma: no cover - defensive
-                    logger.exception(
-                        "[Task #%s] security review crashed", task["id"],
-                    )
-                review_blocks_merge, review_counts = (
-                    _security_review_blocks_merge(task_dir, task["id"])
-                )
-                if review_blocks_merge:
-                    log(
-                        f"[Task #{task['id']}] SECURITY GATE: blocking merge — "
-                        f"{review_counts.get('CRITICAL', 0)} CRITICAL, "
-                        f"{review_counts.get('HIGH', 0)} HIGH finding(s). "
-                        f"Branch forge-task-{task['id']} left unmerged for "
-                        f"operator review.",
-                        output,
-                    )
 
             # Mark for post-gather sequential merge (avoid parallel merge conflicts)
             merge_ok = False

--- a/equipa/dispatch.py
+++ b/equipa/dispatch.py
@@ -51,8 +51,10 @@ from equipa.hooks import fire_async as fire_hook
 from equipa.git_ops import _is_git_repo, git_run_async
 from equipa.lessons import update_injected_episode_q_values_for_task
 from equipa.loops import (
+    _count_findings_in_review_file,
     run_dev_test_loop,
     run_quality_scoring,
+    run_security_review,
 )
 from equipa.manager import run_manager_loop
 from equipa.parsing import _extract_section
@@ -1326,6 +1328,41 @@ async def _cleanup_worktrees(
         pass
 
 
+def _is_security_review_enabled(args) -> bool:
+    """Return True iff security review should run for this dispatch.
+
+    Mirrors the precedence logic in cli.py:run_dispatch (CLI flag wins;
+    falls back to dispatch_config top-level key; features.security_review
+    can disable even when the top-level key is True). Extracted so the
+    single-task and parallel-mode code paths apply the same rule
+    (bug 2321: parallel-mode previously skipped security review entirely).
+    """
+    dc = getattr(args, "dispatch_config", None) or {}
+    enabled = getattr(args, "security_review", None)
+    if enabled is None:
+        enabled = dc.get("security_review", False)
+    if not is_feature_enabled(dc, "security_review"):
+        enabled = False
+    return bool(enabled)
+
+
+def _security_review_blocks_merge(project_dir: str, task_id: int) -> tuple[bool, dict | None]:
+    """Return (blocks_merge, counts) by reading SECURITY-REVIEW-{task_id}.md.
+
+    blocks_merge is True iff the artifact exists AND reports at least one
+    CRITICAL or HIGH finding. If the artifact is missing, returns
+    (False, None) — a missing artifact is logged elsewhere and does NOT
+    block merge on its own (the agent may have produced no findings file
+    on a clean review; future hardening can tighten this).
+    """
+    review_path = Path(project_dir) / f"SECURITY-REVIEW-{task_id}.md"
+    counts = _count_findings_in_review_file(review_path)
+    if counts is None:
+        return False, None
+    blocks = counts.get("CRITICAL", 0) > 0 or counts.get("HIGH", 0) > 0
+    return blocks, counts
+
+
 async def run_parallel_tasks(task_ids: list[int], args) -> None:
     """Run multiple tasks concurrently with dev-test loops.
 
@@ -1506,9 +1543,46 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
                 cycle_number=cycles, output=output,
             )
 
+            # Bug 2321: run security review in parallel-mode BEFORE marking
+            # the task for merge. Single-task mode runs review after a
+            # successful dev-test (cli.py:run_dispatch); parallel mode used
+            # to skip this step entirely, so multi-task dispatches landed
+            # un-reviewed code on master. Review runs inside the worktree
+            # so the artifact is committed and travels with the merge.
+            review_blocks_merge = False
+            review_counts: dict | None = None
+            if (
+                _is_security_review_enabled(args)
+                and outcome in ("tests_passed", "no_tests")
+            ):
+                try:
+                    await run_security_review(
+                        task, task_dir, project_context, args, output=output,
+                    )
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception(
+                        "[Task #%s] security review crashed", task["id"],
+                    )
+                review_blocks_merge, review_counts = (
+                    _security_review_blocks_merge(task_dir, task["id"])
+                )
+                if review_blocks_merge:
+                    log(
+                        f"[Task #{task['id']}] SECURITY GATE: blocking merge — "
+                        f"{review_counts.get('CRITICAL', 0)} CRITICAL, "
+                        f"{review_counts.get('HIGH', 0)} HIGH finding(s). "
+                        f"Branch forge-task-{task['id']} left unmerged for "
+                        f"operator review.",
+                        output,
+                    )
+
             # Mark for post-gather sequential merge (avoid parallel merge conflicts)
             merge_ok = False
-            needs_merge = task["id"] in worktree_dirs and outcome in ("tests_passed", "no_tests")
+            needs_merge = (
+                task["id"] in worktree_dirs
+                and outcome in ("tests_passed", "no_tests")
+                and not review_blocks_merge
+            )
 
             return {
                 "task": task,
@@ -1518,6 +1592,8 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
                 "output": output,
                 "merge_ok": merge_ok,
                 "needs_merge": needs_merge,
+                "review_blocks_merge": review_blocks_merge,
+                "review_counts": review_counts,
             }
 
     results = await asyncio.gather(
@@ -1580,6 +1656,11 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
         merge_candidates = []
         for r in results:
             if isinstance(r, Exception):
+                continue
+            # Bug 2321: skip merge candidates that the security review gated.
+            # needs_merge already encodes review_blocks_merge, but the fallback
+            # outcome check below would otherwise reinstate a blocked task.
+            if r.get("review_blocks_merge", False):
                 continue
             if r.get("needs_merge", False) or (
                 r["task"]["id"] in worktree_dirs

--- a/tests/test_dispatch_parallel_security_review.py
+++ b/tests/test_dispatch_parallel_security_review.py
@@ -1,0 +1,458 @@
+"""Regression tests for bug 2321 — parallel-mode security review gate.
+
+Bug 2321: parallel-isolation mode (--tasks N,M,O with worktrees) auto-
+merged task branches to local master without ever running the security
+reviewer agent, while single-task mode (--task N) did run it. Five
+commits across two repos landed un-reviewed in production before the
+operator caught the divergence.
+
+These tests cover the helpers that gate the merge and the integrated
+parallel-mode dispatch path:
+
+* ``_is_security_review_enabled`` reads the same precedence chain as
+  single-task mode (CLI flag, then dispatch_config top-level, then
+  features.security_review).
+* ``_security_review_blocks_merge`` reads the SECURITY-REVIEW-NNNN.md
+  artifact (NOT raw agent stdout) so the gate uses the same plumbing as
+  task 2315 fixed for the single-task path.
+* ``run_parallel_tasks`` calls ``run_security_review`` once per task that
+  completed dev-test successfully, demotes the outcome on CRITICAL/HIGH
+  findings so the task ends up blocked (not done), and removes the
+  branch from the merge candidate list.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from equipa.dispatch import (
+    _is_security_review_enabled,
+    _security_review_blocks_merge,
+    run_parallel_tasks,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_security_review_enabled — enablement precedence
+# ---------------------------------------------------------------------------
+
+
+def _make_args(
+    security_review=None, dispatch_config=None, yes=True,
+) -> MagicMock:
+    args = MagicMock()
+    args.security_review = security_review
+    args.dispatch_config = dispatch_config or {}
+    args.yes = yes
+    args.max_concurrent = 4
+    args.use_flow = False
+    return args
+
+
+def test_enabled_when_cli_flag_true():
+    args = _make_args(security_review=True, dispatch_config={})
+    assert _is_security_review_enabled(args) is True
+
+
+def test_disabled_when_cli_flag_false():
+    """CLI flag --no-security-review (False) wins over dispatch config."""
+    args = _make_args(
+        security_review=False,
+        dispatch_config={"security_review": True},
+    )
+    assert _is_security_review_enabled(args) is False
+
+
+def test_falls_back_to_dispatch_config_top_level():
+    args = _make_args(
+        security_review=None,
+        dispatch_config={"security_review": True},
+    )
+    assert _is_security_review_enabled(args) is True
+
+
+def test_feature_flag_can_disable_top_level_key():
+    args = _make_args(
+        security_review=None,
+        dispatch_config={
+            "security_review": True,
+            "features": {"security_review": False},
+        },
+    )
+    assert _is_security_review_enabled(args) is False
+
+
+def test_disabled_when_no_flag_and_no_config():
+    args = _make_args()
+    assert _is_security_review_enabled(args) is False
+
+
+# ---------------------------------------------------------------------------
+# _security_review_blocks_merge — read from artifact, not stdout
+# ---------------------------------------------------------------------------
+
+
+def _write_review(path: Path, *, critical: int = 0, high: int = 0,
+                  medium: int = 0, low: int = 0, info: int = 0) -> None:
+    """Build a synthetic SECURITY-REVIEW-NNNN.md with N findings per severity.
+
+    Uses the canonical ``### [TAG-NN] SEVERITY — desc`` header format
+    that ``_count_findings_in_review_file`` matches.
+    """
+    sections = ["# Security Review", ""]
+    for label, n in (
+        ("CRITICAL", critical), ("HIGH", high), ("MEDIUM", medium),
+        ("LOW", low), ("INFO", info),
+    ):
+        for i in range(n):
+            sections.append(f"### [{label[0]}{i + 1}] {label} — finding {i + 1}")
+            sections.append("Some prose describing the finding.")
+            sections.append("")
+    path.write_text("\n".join(sections), encoding="utf-8")
+
+
+def test_blocks_when_critical_present(tmp_path):
+    _write_review(tmp_path / "SECURITY-REVIEW-42.md", critical=1)
+    blocks, counts = _security_review_blocks_merge(str(tmp_path), 42)
+    assert blocks is True
+    assert counts == {"CRITICAL": 1, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "INFO": 0}
+
+
+def test_blocks_when_high_present(tmp_path):
+    _write_review(tmp_path / "SECURITY-REVIEW-42.md", high=2)
+    blocks, counts = _security_review_blocks_merge(str(tmp_path), 42)
+    assert blocks is True
+    assert counts["HIGH"] == 2
+
+
+def test_does_not_block_when_only_medium_low_info(tmp_path):
+    _write_review(
+        tmp_path / "SECURITY-REVIEW-42.md", medium=3, low=5, info=2,
+    )
+    blocks, counts = _security_review_blocks_merge(str(tmp_path), 42)
+    assert blocks is False
+    assert counts["MEDIUM"] == 3
+    assert counts["LOW"] == 5
+    assert counts["INFO"] == 2
+
+
+def test_missing_artifact_does_not_block(tmp_path):
+    """No artifact => (False, None). A missing review is logged elsewhere."""
+    blocks, counts = _security_review_blocks_merge(str(tmp_path), 99)
+    assert blocks is False
+    assert counts is None
+
+
+def test_artifact_count_ignores_severity_words_in_prose(tmp_path):
+    """The gate must count finding headers, not substring 'CRITICAL' in prose.
+
+    This is the same defence that task 2315 added to the single-task
+    path. The gate has to use the helper that reads the artifact, not
+    the raw agent stdout, or it will fire on rejected-finding prose
+    like '[S1] LOW — this is NOT a CRITICAL because…'.
+    """
+    review = tmp_path / "SECURITY-REVIEW-42.md"
+    review.write_text(
+        "# Review\n\n"
+        "### [S1] LOW — this is NOT a CRITICAL vulnerability\n"
+        "The reviewer considered HIGH severity but downgraded after analysis.\n"
+        "\n"
+        "### [S2] INFO — discussion of HIGH-impact edge cases\n",
+        encoding="utf-8",
+    )
+    blocks, counts = _security_review_blocks_merge(str(tmp_path), 42)
+    assert blocks is False, "prose mentions must not trigger the gate"
+    assert counts["CRITICAL"] == 0
+    assert counts["HIGH"] == 0
+    assert counts["LOW"] == 1
+    assert counts["INFO"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: run_parallel_tasks calls security review and gates merge
+# ---------------------------------------------------------------------------
+
+
+def _patch_parallel_mode(
+    tmp_project: Path,
+    *,
+    review_writer,
+    dev_outcome: str = "tests_passed",
+):
+    """Return a list of patches that stub the parallel-mode dependencies.
+
+    Each test invokes ``run_parallel_tasks`` against the same skeleton
+    project so the patches can stay shared. ``review_writer(task_dir,
+    task_id)`` is the hook each test uses to drop (or omit) the
+    SECURITY-REVIEW-NNNN.md artifact.
+    """
+    async def fake_dev_test(task, project_dir, project_context, args,
+                            config, output=None):
+        return (
+            {"cost": 0.0, "duration": 0.0},
+            1,
+            dev_outcome,
+            0.0,
+            0.0,
+            task,
+        )
+
+    async def fake_security_review(task, project_dir, project_context, args,
+                                   output=None):
+        review_writer(Path(project_dir), task["id"])
+        return {"success": True, "duration": 0.0, "result_text": ""}
+
+    async def fake_create_worktrees(tasks, project_dir, worktree_base):
+        out = {}
+        for t in tasks:
+            d = tmp_project / f"wt-{t['id']}"
+            d.mkdir(parents=True, exist_ok=True)
+            out[t["id"]] = str(d)
+        return out
+
+    merge_calls: list[tuple[str, int, str]] = []
+
+    async def fake_merge(project_dir, task_id, branch_name):
+        merge_calls.append((project_dir, task_id, branch_name))
+        return True
+
+    async def fake_cleanup(project_dir, worktree_dirs, merged, base):
+        return None
+
+    patches = [
+        patch("equipa.dispatch.fetch_tasks_by_ids",
+              return_value=[{
+                  "id": 100, "project_id": 1, "title": "t",
+                  "description": "d", "role": "developer",
+              }]),
+        patch("equipa.dispatch.resolve_project_dir",
+              return_value=str(tmp_project)),
+        patch("equipa.dispatch.fetch_project_context", return_value={}),
+        patch("equipa.dispatch._is_git_repo", return_value=True),
+        patch(
+            "equipa.dispatch.run_dev_test_loop_with_autoresearch",
+            side_effect=fake_dev_test,
+        ),
+        patch(
+            "equipa.dispatch.run_security_review",
+            side_effect=fake_security_review,
+        ),
+        patch(
+            "equipa.dispatch._create_isolation_worktrees",
+            side_effect=fake_create_worktrees,
+        ),
+        patch(
+            "equipa.dispatch._merge_task_branch",
+            side_effect=fake_merge,
+        ),
+        patch(
+            "equipa.dispatch._cleanup_worktrees",
+            side_effect=fake_cleanup,
+        ),
+        patch("equipa.dispatch.update_task_status"),
+        patch("equipa.dispatch.record_agent_run"),
+        patch("equipa.dispatch.get_role_model", return_value="opus"),
+        patch("equipa.dispatch.get_role_turns", return_value=10),
+    ]
+    return patches, merge_calls
+
+
+@pytest.mark.asyncio
+async def test_parallel_mode_runs_security_review(tmp_path):
+    """A successful parallel-mode task triggers run_security_review and
+    persists SECURITY-REVIEW-NNNN.md in the worktree."""
+    args = _make_args(
+        security_review=True,
+        dispatch_config={"security_review": True},
+    )
+
+    def writer(task_dir: Path, task_id: int):
+        _write_review(task_dir / f"SECURITY-REVIEW-{task_id}.md")
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    # We also need two tasks to force use_worktrees=True (>1 task).
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 100, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+            {"id": 101, "project_id": 1, "title": "t2",
+             "description": "d", "role": "developer"},
+        ],
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5] as mock_review, patches[6], patches[7], patches[8], \
+         patches[9], patches[10], patches[11], patches[12]:
+        await run_parallel_tasks([100, 101], args)
+
+    # Review was invoked once per task.
+    assert mock_review.call_count == 2
+    # And the artifact landed in each worktree.
+    assert (tmp_path / "wt-100" / "SECURITY-REVIEW-100.md").is_file()
+    assert (tmp_path / "wt-101" / "SECURITY-REVIEW-101.md").is_file()
+    # Both branches merged (clean reviews).
+    merged_ids = {tid for _, tid, _ in merge_calls}
+    assert merged_ids == {100, 101}
+
+
+@pytest.mark.asyncio
+async def test_parallel_mode_blocks_merge_on_critical(tmp_path):
+    """A CRITICAL finding leaves the branch unmerged."""
+    args = _make_args(
+        security_review=True,
+        dispatch_config={"security_review": True},
+    )
+
+    def writer(task_dir: Path, task_id: int):
+        _write_review(
+            task_dir / f"SECURITY-REVIEW-{task_id}.md", critical=1,
+        )
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 200, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+            {"id": 201, "project_id": 1, "title": "t2",
+             "description": "d", "role": "developer"},
+        ],
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], \
+         patches[9] as mock_status, patches[10], patches[11], patches[12]:
+        await run_parallel_tasks([200, 201], args)
+
+    # Critical findings => NO merge.
+    assert merge_calls == []
+    # update_task_status(task_id, outcome, output=...) — outcome arg
+    # is "security_review_blocked", which maps to 'blocked' (not 'done').
+    assert len(mock_status.call_args_list) == 2
+    for c in mock_status.call_args_list:
+        assert c[0][1] == "security_review_blocked", c
+
+
+@pytest.mark.asyncio
+async def test_parallel_mode_blocks_merge_on_high(tmp_path):
+    """A HIGH finding (without CRITICAL) also blocks merge."""
+    args = _make_args(
+        security_review=True,
+        dispatch_config={"security_review": True},
+    )
+
+    def writer(task_dir: Path, task_id: int):
+        _write_review(task_dir / f"SECURITY-REVIEW-{task_id}.md", high=2)
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 300, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+            {"id": 301, "project_id": 1, "title": "t2",
+             "description": "d", "role": "developer"},
+        ],
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], \
+         patches[10], patches[11], patches[12]:
+        await run_parallel_tasks([300, 301], args)
+
+    assert merge_calls == [], "HIGH findings must also gate the merge"
+
+
+@pytest.mark.asyncio
+async def test_parallel_mode_review_uses_count_from_artifact(tmp_path):
+    """The gate reads the artifact (task 2315 plumbing), not raw stdout.
+
+    Even when the review agent's stdout contains the words 'CRITICAL'
+    and 'HIGH' all over the place, only counts derived from the
+    SECURITY-REVIEW-NNNN.md file may trigger the gate.
+    """
+    args = _make_args(
+        security_review=True,
+        dispatch_config={"security_review": True},
+    )
+
+    def writer(task_dir: Path, task_id: int):
+        # Artifact reports MEDIUM only — should NOT block.
+        review = task_dir / f"SECURITY-REVIEW-{task_id}.md"
+        review.write_text(
+            "### [M1] MEDIUM — minor issue\nDescribed.\n", encoding="utf-8",
+        )
+
+    async def chatty_review(task, project_dir, project_context, args,
+                            output=None):
+        writer(Path(project_dir), task["id"])
+        # The stdout text mentions CRITICAL/HIGH but those are prose.
+        return {
+            "success": True,
+            "duration": 0.0,
+            "result_text": (
+                "[S1] LOW — this is NOT a CRITICAL vulnerability "
+                "and would not be HIGH either."
+            ),
+        }
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 400, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+            {"id": 401, "project_id": 1, "title": "t2",
+             "description": "d", "role": "developer"},
+        ],
+    )
+    # Replace the review patch with the chatty one.
+    patches[5] = patch(
+        "equipa.dispatch.run_security_review", side_effect=chatty_review,
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], \
+         patches[10], patches[11], patches[12]:
+        await run_parallel_tasks([400, 401], args)
+
+    # Artifact is MEDIUM-only — both branches must merge despite
+    # 'CRITICAL'/'HIGH' substrings in the agent's prose.
+    merged_ids = {tid for _, tid, _ in merge_calls}
+    assert merged_ids == {400, 401}
+
+
+@pytest.mark.asyncio
+async def test_parallel_mode_skips_review_when_disabled(tmp_path):
+    """When security_review is disabled, the helper is never called and
+    every successful task is still merged (pre-2321 behaviour intact)."""
+    args = _make_args(
+        security_review=False, dispatch_config={"security_review": False},
+    )
+
+    def writer(task_dir: Path, task_id: int):  # pragma: no cover
+        raise AssertionError("review must not run when disabled")
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 500, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+            {"id": 501, "project_id": 1, "title": "t2",
+             "description": "d", "role": "developer"},
+        ],
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5] as mock_review, patches[6], patches[7], patches[8], \
+         patches[9], patches[10], patches[11], patches[12]:
+        await run_parallel_tasks([500, 501], args)
+
+    mock_review.assert_not_called()
+    merged_ids = {tid for _, tid, _ in merge_calls}
+    assert merged_ids == {500, 501}


### PR DESCRIPTION
**Closes TheForge bug 2321.** Parallel-isolation mode (`--tasks N,M,O`) was auto-merging branches to local master WITHOUT running the security review step that single-task mode (`--task N`) runs. Caught after five parallel-isolation tasks (2079, 2214, 2315, 2319, 2322/2324) landed on master with no security review file. Operator had to manually review each diff before pushing.

## Diff (3 commits, 2 files, +543/-1)

- **`equipa/dispatch.py`** (+86) — Three additions to `run_parallel_tasks`:
  1. `_is_security_review_enabled(args)` — extracts the precedence chain (CLI flag → `dispatch_config.security_review` → `features.security_review`) into a shared helper. Same shape as the single-task code path in `cli.py:run_dispatch`.
  2. `_security_review_blocks_merge(project_dir, task_id)` — reads `SECURITY-REVIEW-{task_id}.md` via the `_count_findings_in_review_file` extractor from task 2315; returns `(True, counts)` if CRITICAL or HIGH > 0.
  3. After dev-test passes in parallel mode, run `run_security_review`, then evaluate the artifact. CRITICAL/HIGH findings demote outcome to a new `security_review_blocked` state and set `needs_merge = False`. `update_task_status` already maps that outcome to `blocked`, so the task is NOT marked done.
- **`tests/test_dispatch_parallel_security_review.py`** (+458) — 15 new tests covering: feature enable/disable matrix, CRITICAL/HIGH gate triggers, no-findings happy path, outcome demotion, merge skip on block, missing-artifact behavior, parametrized severity tables. All 15 pass.

## Security review (SECURITY-REVIEW-2321.md saved to project root)

**Verdict: APPROVE**, 0 CRITICAL, 0 HIGH, 3 INFO observations:

- **S1** — Missing artifact = unblocked merge (fail-open). Intentional per docstring; flag for future hardening.
- **S2** — `except Exception` around `run_security_review` falls through to "no findings" if the review crashes (fail-open). Same shape as S1.
- **S3** — Precedence-extraction helper now duplicates the cli.py chain. Same divergence pattern that caused 2321 itself. Long-term: extract one shared helper.

All three INFO items will be filed as a follow-up task.

## Test results

```
$ pytest tests/test_dispatch_parallel_security_review.py -q
15 passed in 0.33s

$ pytest tests/ -k 'security_review or dispatch or parallel' -q
56 passed, 1497 deselected in 8.92s
```

## What this fixes operationally

Before this fix, an EQUIPA `--tasks N,M,O` dispatch could land code on master that no agent ever reviewed. Operator was the de-facto security reviewer for parallel-mode commits — high attention cost, error-prone. After this fix:

- Parallel mode runs the same `run_security_review` that single-mode does
- Branches with CRITICAL/HIGH findings are LEFT UNMERGED, task marked `blocked` (not `done`)
- Operator sees a SECURITY GATE log line and can review the artifact + branch deliberately
- No CRITICAL/HIGH = transparent auto-merge, same as before

## Test plan

- [x] `pytest tests/test_dispatch_parallel_security_review.py` — 15/15 PASS
- [x] `pytest tests/` cross-section — 56/56 PASS on dispatch/security_review/parallel-keyed tests
- [x] Manual code review (this PR description doubles as the operator review)
- [ ] Reviewer: confirm `update_task_status` maps `security_review_blocked` outcome to `blocked` task status (see equipa/db.py:390-435 per security review)

## Out of scope

- S1/S2 fail-closed hardening (separate task)
- S3 precedence extraction (separate task)
- Bypassing the gate (no escape hatch added — operator must merge manually if they accept the findings)
