### PR TITLE
fix(dispatch): fail-closed on missing security-review artifact + reviewer crash (bug 2341)

### DIFF
--- a/dispatch_config.example.json
+++ b/dispatch_config.example.json
@@ -51,6 +51,7 @@
         "forgesmith_episodes": true,
         "gepa_ab_testing": false,
         "security_review": true,
+        "security_review_block_on_missing_artifact": true,
         "quality_scoring": true,
         "anti_compaction_state": true,
         "vector_memory": false,

--- a/equipa/config.py
+++ b/equipa/config.py
@@ -34,6 +34,12 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     "forgesmith_episodes": True,
     "gepa_ab_testing": False,
     "security_review": True,
+    # When True (default), a missing SECURITY-REVIEW-NNNN.md artifact after
+    # the security-review agent runs is treated as a gate-blocking failure
+    # (fail-closed). Set to False only if your workflow accepts the
+    # pre-2341 trade-off: a crashed/silenced reviewer silently downgrades
+    # to "no findings" and the branch is allowed to merge. See task 2341.
+    "security_review_block_on_missing_artifact": True,
     "quality_scoring": True,
     "anti_compaction_state": True,
     "vector_memory": False,

--- a/equipa/dispatch.py
+++ b/equipa/dispatch.py
@@ -1346,18 +1346,46 @@ def _is_security_review_enabled(args) -> bool:
     return bool(enabled)
 
 
-def _security_review_blocks_merge(project_dir: str, task_id: int) -> tuple[bool, dict | None]:
+def _security_review_blocks_merge(
+    project_dir: str,
+    task_id: int,
+    *,
+    block_on_missing: bool = True,
+) -> tuple[bool, dict | None]:
     """Return (blocks_merge, counts) by reading SECURITY-REVIEW-{task_id}.md.
 
-    blocks_merge is True iff the artifact exists AND reports at least one
-    CRITICAL or HIGH finding. If the artifact is missing, returns
-    (False, None) — a missing artifact is logged elsewhere and does NOT
-    block merge on its own (the agent may have produced no findings file
-    on a clean review; future hardening can tighten this).
+    blocks_merge is True when:
+      * the artifact exists AND reports at least one CRITICAL or HIGH
+        finding, OR
+      * the artifact is MISSING and ``block_on_missing`` is True
+        (fail-closed; default).
+
+    The fail-closed default is task 2341's S1 hardening over the original
+    bug-2321 fix: a reviewer agent that crashes, times out, or is steered
+    off-task by content in the task description can satisfy the
+    pre-2341 (False, None) contract simply by not writing the artifact —
+    same shape as the original 2321 vulnerability, narrower scope.
+    Operators who need the legacy fail-open behaviour can disable the
+    ``security_review_block_on_missing_artifact`` feature flag.
     """
     review_path = Path(project_dir) / f"SECURITY-REVIEW-{task_id}.md"
     counts = _count_findings_in_review_file(review_path)
     if counts is None:
+        if block_on_missing:
+            logger.warning(
+                "[security-review] missing artifact %s — gating merge "
+                "(fail-closed). Disable features."
+                "security_review_block_on_missing_artifact to allow "
+                "legacy fail-open behaviour.",
+                review_path,
+            )
+            return True, None
+        logger.warning(
+            "[security-review] missing artifact %s — fail-open mode "
+            "(features.security_review_block_on_missing_artifact=False); "
+            "merge will proceed without findings data.",
+            review_path,
+        )
         return False, None
     blocks = counts.get("CRITICAL", 0) > 0 or counts.get("HIGH", 0) > 0
     return blocks, counts
@@ -1529,26 +1557,65 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
                 _is_security_review_enabled(args)
                 and outcome in ("tests_passed", "no_tests")
             ):
+                # Task 2341 S2: if run_security_review raises, the artifact
+                # check on its own is not enough to gate the merge — a
+                # stale SECURITY-REVIEW-NNNN.md from a prior run could
+                # exist in the worktree and silently re-authorise. The
+                # explicit flag here ensures a crashed reviewer always
+                # blocks, independently of artifact state.
+                review_crashed = False
                 try:
                     await run_security_review(
                         task, task_dir, project_context, args, output=output,
                     )
                 except Exception:  # pragma: no cover - defensive
+                    review_crashed = True
                     logger.exception(
                         "[Task #%s] security review crashed", task["id"],
                     )
-                review_blocks_merge, review_counts = (
-                    _security_review_blocks_merge(task_dir, task["id"])
+                _config_for_flag = getattr(args, "dispatch_config", None) or {}
+                _block_on_missing = is_feature_enabled(
+                    _config_for_flag,
+                    "security_review_block_on_missing_artifact",
                 )
-                if review_blocks_merge:
+                review_blocks_merge, review_counts = (
+                    _security_review_blocks_merge(
+                        task_dir, task["id"],
+                        block_on_missing=_block_on_missing,
+                    )
+                )
+                if review_crashed:
+                    # Fail-closed: the review pipeline crashed, do not
+                    # trust the artifact check. Override any (False, ...)
+                    # result the artifact reader returned.
+                    review_blocks_merge = True
                     log(
                         f"[Task #{task['id']}] SECURITY GATE: blocking merge — "
-                        f"{review_counts.get('CRITICAL', 0)} CRITICAL, "
-                        f"{review_counts.get('HIGH', 0)} HIGH finding(s). "
-                        f"Branch forge-task-{task['id']} left unmerged for "
-                        f"operator review.",
+                        f"security review crashed; branch forge-task-"
+                        f"{task['id']} left unmerged for operator review.",
                         output,
                     )
+                    outcome = "security_review_blocked"
+                elif review_blocks_merge:
+                    if review_counts is None:
+                        log(
+                            f"[Task #{task['id']}] SECURITY GATE: blocking "
+                            f"merge — SECURITY-REVIEW-{task['id']}.md "
+                            f"artifact is missing (fail-closed). Branch "
+                            f"forge-task-{task['id']} left unmerged for "
+                            f"operator review.",
+                            output,
+                        )
+                    else:
+                        log(
+                            f"[Task #{task['id']}] SECURITY GATE: blocking "
+                            f"merge — {review_counts.get('CRITICAL', 0)} "
+                            f"CRITICAL, {review_counts.get('HIGH', 0)} "
+                            f"HIGH finding(s). Branch forge-task-"
+                            f"{task['id']} left unmerged for operator "
+                            f"review.",
+                            output,
+                        )
                     outcome = "security_review_blocked"
 
             update_task_status(task["id"], outcome, output=output)

--- a/tests/test_dispatch_parallel_security_review.py
+++ b/tests/test_dispatch_parallel_security_review.py
@@ -139,9 +139,24 @@ def test_does_not_block_when_only_medium_low_info(tmp_path):
     assert counts["INFO"] == 2
 
 
-def test_missing_artifact_does_not_block(tmp_path):
-    """No artifact => (False, None). A missing review is logged elsewhere."""
+def test_missing_artifact_blocks_by_default(tmp_path):
+    """Task 2341 S1: missing artifact is fail-closed by default.
+
+    The pre-2341 contract returned (False, None) — a crashed reviewer
+    that never wrote the artifact would silently authorise the merge.
+    The default is now (True, None): operators must opt out via
+    features.security_review_block_on_missing_artifact=False.
+    """
     blocks, counts = _security_review_blocks_merge(str(tmp_path), 99)
+    assert blocks is True
+    assert counts is None
+
+
+def test_missing_artifact_does_not_block_when_flag_disabled(tmp_path):
+    """Operator opt-out via block_on_missing=False restores fail-open."""
+    blocks, counts = _security_review_blocks_merge(
+        str(tmp_path), 99, block_on_missing=False,
+    )
     assert blocks is False
     assert counts is None
 
@@ -456,3 +471,187 @@ async def test_parallel_mode_skips_review_when_disabled(tmp_path):
     mock_review.assert_not_called()
     merged_ids = {tid for _, tid, _ in merge_calls}
     assert merged_ids == {500, 501}
+
+
+# ---------------------------------------------------------------------------
+# Task 2341 — fail-closed regressions for missing artifact + reviewer crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_artifact_blocks_merge_by_default(tmp_path):
+    """S1 regression: review agent that does not write the artifact
+    must NOT silently authorise the merge (pre-2341 vulnerability).
+    """
+    args = _make_args(
+        security_review=True,
+        dispatch_config={"security_review": True},
+    )
+
+    def writer(task_dir: Path, task_id: int):
+        # Reviewer runs but produces no artifact (e.g. crashed silently,
+        # was steered off-task by description content, or wrote to the
+        # wrong path).
+        return None
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 600, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+            {"id": 601, "project_id": 1, "title": "t2",
+             "description": "d", "role": "developer"},
+        ],
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], \
+         patches[9] as mock_status, patches[10], patches[11], patches[12]:
+        await run_parallel_tasks([600, 601], args)
+
+    assert merge_calls == [], "missing artifact must block merge by default"
+    assert len(mock_status.call_args_list) == 2
+    for c in mock_status.call_args_list:
+        assert c[0][1] == "security_review_blocked", c
+
+
+@pytest.mark.asyncio
+async def test_review_crash_blocks_merge(tmp_path):
+    """S2 regression: run_security_review raising must gate the merge
+    even if a stale SECURITY-REVIEW-NNNN.md from a prior run exists.
+    """
+    args = _make_args(
+        security_review=True,
+        dispatch_config={"security_review": True},
+    )
+
+    def writer(task_dir: Path, task_id: int):
+        # Simulate a stale clean review on disk from a previous run.
+        # If the gate trusted the artifact alone, the crash would be
+        # invisible and the merge would proceed.
+        _write_review(task_dir / f"SECURITY-REVIEW-{task_id}.md")
+
+    async def crashing_review(task, project_dir, project_context, args,
+                              output=None):
+        writer(Path(project_dir), task["id"])
+        raise RuntimeError("network outage during review")
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 700, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+            {"id": 701, "project_id": 1, "title": "t2",
+             "description": "d", "role": "developer"},
+        ],
+    )
+    patches[5] = patch(
+        "equipa.dispatch.run_security_review", side_effect=crashing_review,
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], \
+         patches[9] as mock_status, patches[10], patches[11], patches[12]:
+        await run_parallel_tasks([700, 701], args)
+
+    assert merge_calls == [], (
+        "reviewer crash must block merge regardless of stale artifact"
+    )
+    for c in mock_status.call_args_list:
+        assert c[0][1] == "security_review_blocked", c
+
+
+@pytest.mark.asyncio
+async def test_missing_artifact_unblocks_with_flag(tmp_path):
+    """Operator opt-out: setting features."
+    "security_review_block_on_missing_artifact=False restores the
+    pre-2341 fail-open behaviour for shops whose workflow needs it.
+    """
+    args = _make_args(
+        security_review=True,
+        dispatch_config={
+            "security_review": True,
+            "features": {
+                "security_review": True,
+                "security_review_block_on_missing_artifact": False,
+            },
+        },
+    )
+
+    def writer(task_dir: Path, task_id: int):
+        return None  # no artifact
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 800, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+            {"id": 801, "project_id": 1, "title": "t2",
+             "description": "d", "role": "developer"},
+        ],
+    )
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], patches[9], \
+         patches[10], patches[11], patches[12]:
+        await run_parallel_tasks([800, 801], args)
+
+    merged_ids = {tid for _, tid, _ in merge_calls}
+    assert merged_ids == {800, 801}, (
+        "fail-open opt-out must allow merges with missing artifact"
+    )
+
+
+@pytest.mark.asyncio
+async def test_review_crash_logs_traceback(tmp_path, caplog):
+    """The exception handler still records logger.exception() output so
+    operators can diagnose reviewer failures even though the gate now
+    blocks rather than falling through.
+    """
+    import logging
+
+    args = _make_args(
+        security_review=True,
+        dispatch_config={"security_review": True},
+    )
+
+    def writer(task_dir: Path, task_id: int):
+        return None
+
+    async def crashing_review(task, project_dir, project_context, args,
+                              output=None):
+        raise RuntimeError("boom")
+
+    patches, merge_calls = _patch_parallel_mode(tmp_path, review_writer=writer)
+    patches[0] = patch(
+        "equipa.dispatch.fetch_tasks_by_ids",
+        return_value=[
+            {"id": 900, "project_id": 1, "title": "t1",
+             "description": "d", "role": "developer"},
+        ],
+    )
+    patches[5] = patch(
+        "equipa.dispatch.run_security_review", side_effect=crashing_review,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="equipa.dispatch"):
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patches[5], patches[6], patches[7], patches[8], patches[9], \
+             patches[10], patches[11], patches[12]:
+            await run_parallel_tasks([900], args)
+
+    # logger.exception() records at ERROR level with the traceback;
+    # capture confirms the diagnostic survived the new gating path.
+    crash_records = [
+        r for r in caplog.records
+        if "security review crashed" in r.getMessage()
+    ]
+    assert crash_records, (
+        "logger.exception must still fire so operators see the traceback"
+    )
+    assert crash_records[0].exc_info is not None
+    # And the gate still blocked the merge.
+    assert merge_calls == []

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -83,6 +83,7 @@ class TestDefaultFeatureFlags(unittest.TestCase):
         "forgesmith_episodes": True,
         "gepa_ab_testing": False,
         "security_review": True,
+        "security_review_block_on_missing_artifact": True,
         "quality_scoring": True,
         "anti_compaction_state": True,
         "vector_memory": False,


### PR DESCRIPTION
**Closes TheForge bug 2341.** Follow-up to bug 2321 (parallel-mode security review). Hardens the gate from fail-open to fail-closed on two paths that bug 2321's INFO findings S1 + S2 flagged.

## What was wrong before this PR

After bug 2321 landed, parallel-mode runs `run_security_review` before merging. But the gate was fail-open in two narrow scenarios:

- **S1**: When `SECURITY-REVIEW-{task_id}.md` was MISSING after the review agent ran, `_count_findings_in_review_file` returned `None` and the helper returned `(False, None)`. A reviewer agent that crashed, timed out, or was steered off-task could bypass the gate simply by not writing the artifact — same shape as the original bug 2321 (just narrower in scope).
- **S2**: A broad `except Exception` wraps `run_security_review`. If the review pipeline crashed, the log recorded the traceback but execution fell through to the artifact check, which (per S1) returned no-block. Flaky network = silent downgrade to pre-2321 behavior.

## What this fix does

1. **`_security_review_blocks_merge(project_dir, task_id, *, block_on_missing=True)`** — new kwarg. Missing artifact + `block_on_missing=True` returns `(True, None)` with a WARNING log that includes the opt-out flag name. Missing artifact + `block_on_missing=False` (legacy) returns `(False, None)` with a different WARNING that the gate is in fail-open mode.
2. **Explicit `review_crashed` flag** in `run_parallel_tasks`. Set inside `except Exception`. After the artifact check, if `review_crashed` is True, **overrides** `review_blocks_merge=True` regardless of what the artifact reader returned. This covers the case where a stale artifact from a prior run exists at the same path.
3. **Three distinct gate-blocking log lines** so operators can tell at a glance whether the merge was blocked by:
   - findings (CRITICAL/HIGH counts visible)
   - missing artifact (fail-closed default)
   - reviewer crash
4. **New feature flag** `security_review_block_on_missing_artifact` in `dispatch_config.example.json`, defaults to True (fail-closed). Operators who need legacy fail-open can flip it.

## Diff (2 commits, 5 files, +288/-14)

| File | Lines | Purpose |
|---|---:|---|
| `equipa/dispatch.py` | +91/-14 | `_security_review_blocks_merge` kwarg, `review_crashed` flag, three log paths |
| `equipa/config.py` | +6 | Register new feature flag with default True |
| `dispatch_config.example.json` | +1 | Document the flag |
| `tests/test_dispatch_parallel_security_review.py` | +203 | All 4 task-mandated regression tests + opt-out test |
| `tests/test_feature_flags.py` | +1 | New flag default verification |

## Verification

- `pytest tests/test_dispatch_parallel_security_review.py tests/test_feature_flags.py` → **PASS**
- Full suite at PR-creation time: 1558/1558 (per orchestrator log)

## Security review (saved as `SECURITY-REVIEW-2341.md`)

**Verdict: APPROVE**, 0 CRITICAL, 0 HIGH, 2 INFO observations:

- **S1** — Crash-path log discards counts from any pre-existing artifact (diagnostic completeness only). The `logger.exception` traceback still has the crash details.
- **S2** — Stale artifact from a re-used task_id could still satisfy a *non-crashing* reviewer that doesn't write a fresh one. Narrow residual case (worktree directory recycled + task replayed). Reviewer recommends future hardening to delete the prior artifact before `run_security_review` runs.

Both are quality observations, not exploitable. Filing as a small follow-up; not gating this PR.

## What this unblocks

Operators no longer need to grep the dispatcher log for "security review crashed" before trusting a parallel-mode auto-merge. The gate is now fail-closed by default and the opt-out is a documented config knob with a WARNING log on every miss.

## Test plan

- [x] `pytest tests/test_dispatch_parallel_security_review.py` — PASS (all 4 task-mandated tests)
- [x] `pytest tests/test_feature_flags.py` — PASS
- [ ] Reviewer: confirm `is_feature_enabled` returns True when the operator's `dispatch_config.json` has NO `features` key (default-fallback behavior is the entire point)
- [ ] Reviewer: spot-check the three distinct SECURITY GATE log lines render correctly

## Out of scope (deferred to follow-ups)

- S1 INFO: append findings count to the crash-path log line
- S2 INFO: delete pre-existing `SECURITY-REVIEW-{task_id}.md` before `run_security_review` runs
- S3 from 2321 (precedence helper extraction) — separate task 2342
