### PR TITLE
refactor(security-review): extract single enablement precedence helper (S3 follow-up to bug 2321)

### DIFF
--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -32,6 +32,7 @@ from equipa.constants import (
 from equipa.agent_runner import build_cli_command, run_agent_streaming, run_agent_with_retries
 from equipa.checkpoints import load_checkpoint
 from equipa.db import record_agent_run, update_task_status
+from equipa.config import is_security_review_enabled
 from equipa.dispatch import (
     _build_dispatch_attempt_reflection,
     apply_dispatch_filters,
@@ -1021,18 +1022,14 @@ async def run_mode_task(args: argparse.Namespace) -> None:
             cycle_number=cycles,
             dispatch_config=getattr(args, "dispatch_config", None))
 
-        # Optional security review after successful dev-test
-        # CLI --security-review flag takes precedence, then dispatch config top-level key,
-        # then features.security_review flag (all must agree for review to run)
-        dc = getattr(args, "dispatch_config", None) or {}
-        security_review_enabled = args.security_review
-        if security_review_enabled is None:
-            security_review_enabled = dc.get("security_review", False)
-        # Feature flag can disable even if top-level key is True
-        if not is_feature_enabled(dc, "security_review"):
-            security_review_enabled = False
-
-        if security_review_enabled and outcome in ("tests_passed", "no_tests"):
+        # Optional security review after successful dev-test. Enablement
+        # precedence (CLI flag > dispatch_config top-level > features kill-switch)
+        # lives in equipa.config.is_security_review_enabled — shared with
+        # the parallel-mode path in equipa.dispatch (bug 2321 S3 follow-up).
+        if (
+            is_security_review_enabled(args)
+            and outcome in ("tests_passed", "no_tests")
+        ):
             await run_security_review(task, project_dir, project_context, args)
 
         # Verify the task status in TheForge

--- a/equipa/config.py
+++ b/equipa/config.py
@@ -80,6 +80,41 @@ def is_feature_enabled(dispatch_config: dict | None, feature_name: str) -> bool:
     return features.get(feature_name, DEFAULT_FEATURE_FLAGS.get(feature_name, False))
 
 
+def is_security_review_enabled(args, dispatch_config: dict | None = None) -> bool:
+    """Return True iff security review should run for this dispatch.
+
+    Single source of truth for the security-review enablement precedence:
+      1. CLI flag ``args.security_review`` wins when not None.
+      2. Otherwise, fall back to ``dispatch_config["security_review"]`` (top-level).
+      3. The ``features.security_review`` feature flag can disable even when
+         the higher-precedence sources enable it (kill-switch semantics).
+
+    This helper was extracted from the duplicate precedence chains that
+    previously lived inline in ``equipa.cli:run_dispatch`` and
+    ``equipa.dispatch:_is_security_review_enabled``. Bug 2321 was caused
+    by exactly this kind of silent divergence between two code paths
+    implementing the same policy; centralising the rule here prevents
+    a recurrence.
+
+    Args:
+        args: argparse Namespace (or any object) with a ``security_review``
+            attribute. Missing attribute is treated as None.
+        dispatch_config: parsed dispatch config dict. If None, falls back
+            to ``getattr(args, "dispatch_config", None)`` for callers
+            (such as the dispatch.py call site) that thread the config
+            through args instead of passing it explicitly.
+    """
+    dc = dispatch_config
+    if dc is None:
+        dc = getattr(args, "dispatch_config", None) or {}
+    enabled = getattr(args, "security_review", None)
+    if enabled is None:
+        enabled = dc.get("security_review", False)
+    if not is_feature_enabled(dc, "security_review"):
+        enabled = False
+    return bool(enabled)
+
+
 def load_dispatch_config(filepath: str | Path | None) -> dict:
     """Load dispatch_config.json preferences.
 

--- a/equipa/dispatch.py
+++ b/equipa/dispatch.py
@@ -29,6 +29,7 @@ from equipa.config import (
     DEFAULT_DISPATCH_CONFIG,
     DEFAULT_FEATURE_FLAGS,
     is_feature_enabled,
+    is_security_review_enabled,
     load_dispatch_config,
 )
 from equipa.constants import (
@@ -1328,24 +1329,6 @@ async def _cleanup_worktrees(
         pass
 
 
-def _is_security_review_enabled(args) -> bool:
-    """Return True iff security review should run for this dispatch.
-
-    Mirrors the precedence logic in cli.py:run_dispatch (CLI flag wins;
-    falls back to dispatch_config top-level key; features.security_review
-    can disable even when the top-level key is True). Extracted so the
-    single-task and parallel-mode code paths apply the same rule
-    (bug 2321: parallel-mode previously skipped security review entirely).
-    """
-    dc = getattr(args, "dispatch_config", None) or {}
-    enabled = getattr(args, "security_review", None)
-    if enabled is None:
-        enabled = dc.get("security_review", False)
-    if not is_feature_enabled(dc, "security_review"):
-        enabled = False
-    return bool(enabled)
-
-
 def _security_review_blocks_merge(
     project_dir: str,
     task_id: int,
@@ -1554,7 +1537,7 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
             review_blocks_merge = False
             review_counts: dict | None = None
             if (
-                _is_security_review_enabled(args)
+                is_security_review_enabled(args)
                 and outcome in ("tests_passed", "no_tests")
             ):
                 # Task 2341 S2: if run_security_review raises, the artifact

--- a/tests/test_dispatch_parallel_security_review.py
+++ b/tests/test_dispatch_parallel_security_review.py
@@ -9,8 +9,9 @@ operator caught the divergence.
 These tests cover the helpers that gate the merge and the integrated
 parallel-mode dispatch path:
 
-* ``_is_security_review_enabled`` reads the same precedence chain as
-  single-task mode (CLI flag, then dispatch_config top-level, then
+* ``is_security_review_enabled`` (extracted to ``equipa.config`` in the
+  bug 2321 S3 follow-up) reads the same precedence chain as single-task
+  mode (CLI flag, then dispatch_config top-level, then
   features.security_review).
 * ``_security_review_blocks_merge`` reads the SECURITY-REVIEW-NNNN.md
   artifact (NOT raw agent stdout) so the gate uses the same plumbing as
@@ -28,15 +29,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from equipa.config import is_security_review_enabled as _is_security_review_enabled
 from equipa.dispatch import (
-    _is_security_review_enabled,
     _security_review_blocks_merge,
     run_parallel_tasks,
 )
 
 
 # ---------------------------------------------------------------------------
-# _is_security_review_enabled — enablement precedence
+# is_security_review_enabled — enablement precedence
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_security_review_config.py
+++ b/tests/test_security_review_config.py
@@ -1,0 +1,118 @@
+"""Unit tests for ``equipa.config.is_security_review_enabled``.
+
+Bug 2321 was caused by two divergent implementations of the security-review
+enablement precedence chain (one in ``equipa.cli:run_dispatch``, one in
+``equipa.dispatch:_is_security_review_enabled``). The S3 follow-up
+extracted a single canonical helper into ``equipa.config`` so both call
+sites apply identical rules.
+
+Precedence (highest first):
+  1. CLI flag ``args.security_review`` (when not None).
+  2. ``dispatch_config["security_review"]`` top-level key.
+  3. ``features.security_review`` feature flag — kill-switch that can
+     disable even when (1) or (2) would enable.
+
+Copyright 2026 Forgeborn
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from equipa.config import is_security_review_enabled
+
+
+def _args(security_review=None, dispatch_config=None) -> SimpleNamespace:
+    """Build a minimal argparse-like Namespace for the helper."""
+    return SimpleNamespace(
+        security_review=security_review,
+        dispatch_config=dispatch_config or {},
+    )
+
+
+def test_cli_flag_overrides_config_disabled():
+    """--security-review on CLI wins even when dispatch config disables."""
+    args = _args(
+        security_review=True,
+        dispatch_config={"security_review": False},
+    )
+    assert is_security_review_enabled(args) is True
+
+
+def test_cli_flag_false_overrides_config_enabled():
+    """--no-security-review on CLI wins even when dispatch config enables."""
+    args = _args(
+        security_review=False,
+        dispatch_config={"security_review": True},
+    )
+    assert is_security_review_enabled(args) is False
+
+
+def test_config_top_level_when_no_cli():
+    """dispatch_config.security_review=True enables when CLI flag unset."""
+    args = _args(
+        security_review=None,
+        dispatch_config={"security_review": True},
+    )
+    assert is_security_review_enabled(args) is True
+
+
+def test_feature_flag_can_disable():
+    """features.security_review=False disables regardless of CLI/config."""
+    args = _args(
+        security_review=True,
+        dispatch_config={
+            "security_review": True,
+            "features": {"security_review": False},
+        },
+    )
+    assert is_security_review_enabled(args) is False
+
+
+def test_feature_flag_can_disable_config_top_level():
+    """Feature flag also disables the dispatch_config top-level path."""
+    args = _args(
+        security_review=None,
+        dispatch_config={
+            "security_review": True,
+            "features": {"security_review": False},
+        },
+    )
+    assert is_security_review_enabled(args) is False
+
+
+def test_default_disabled_when_unset():
+    """No CLI flag, no dispatch_config = disabled."""
+    args = _args(security_review=None, dispatch_config={})
+    assert is_security_review_enabled(args) is False
+
+
+def test_explicit_dispatch_config_arg_overrides_args_attr():
+    """When dispatch_config is passed explicitly, it takes priority over
+    args.dispatch_config — supports call sites that thread config separately."""
+    args = _args(
+        security_review=None,
+        dispatch_config={"security_review": False},
+    )
+    # Explicit override should enable even though args.dispatch_config disables.
+    assert (
+        is_security_review_enabled(
+            args, dispatch_config={"security_review": True}
+        )
+        is True
+    )
+
+
+def test_missing_security_review_attr_on_args():
+    """An args-like object without ``security_review`` falls back to config."""
+    args = SimpleNamespace(dispatch_config={"security_review": True})
+    assert is_security_review_enabled(args) is True
+
+
+def test_none_dispatch_config_uses_args_fallback():
+    """Passing dispatch_config=None falls back to args.dispatch_config."""
+    args = _args(
+        security_review=None,
+        dispatch_config={"security_review": True},
+    )
+    assert is_security_review_enabled(args, dispatch_config=None) is True


### PR DESCRIPTION
**Closes TheForge bug 2342.** S3 follow-up to bug 2321 — closes the silent-divergence shape that caused 2321 itself.

## Why this is important

Bug 2321 happened because two code paths (single-task vs parallel-mode) silently diverged on whether to run the security review. The fix added a `_is_security_review_enabled` helper to `dispatch.py` — but the same 10-line precedence chain was already inlined in `cli.py:run_mode_task`. Now we had TWO copies of the same policy living in lockstep. That is the exact systemic risk that produced 2321.

## What this does

Moves the canonical precedence implementation to a single helper `equipa.config.is_security_review_enabled(args, dispatch_config) -> bool`. Both call sites now route through it. The duplicate is deleted.

Precedence chain (unchanged): **CLI flag** (`args.security_review`) wins → falls back to **dispatch_config top-level** (`dc.get("security_review")`) → can be disabled by the **feature flag** kill-switch (`features.security_review = False`).

## Diff (1 commit, 5 files, +169/-35)

| File | Lines | Purpose |
|---|---:|---|
| `equipa/config.py` | +35 | New `is_security_review_enabled` helper — single source of truth |
| `equipa/cli.py` | -10 inline / +call | Replace 10-line inline block with helper call |
| `equipa/dispatch.py` | -16 / +call | Delete `_is_security_review_enabled`; call shared helper |
| `tests/test_security_review_config.py` | +118 (new) | 9 unit tests covering precedence + edge cases |
| `tests/test_dispatch_parallel_security_review.py` | -3/+9 | Update imports to new helper location |

## Test results

- `pytest tests/test_security_review_config.py tests/test_dispatch_parallel_security_review.py` → **29/29 PASS**
- Full suite at PR-creation time: **1567/1567 PASS** (per orchestrator log)

## Security review (saved as `SECURITY-REVIEW-2342.md`)

**Verdict: APPROVE**. 0 CRITICAL, 0 HIGH, 0 MEDIUM, 0 LOW. 2 INFO observations:

- **S1**: `getattr(args, "security_review", None)` is slightly more lenient than direct attr access (returns None on missing attr instead of `AttributeError`). For argparse namespaces this is a non-issue (the attribute is always present after `parse_args`). Test `test_missing_security_review_attr_on_args` documents the behavior intentionally.
- **S2**: `dc.get("security_review", False)` followed by `bool(enabled)` accepts arbitrary truthy values — string `"false"` would enable since the string is truthy. **This is pre-existing behavior, preserved bit-for-bit by the refactor.** The downstream fail-closed gate from task 2341 still blocks merge if no artifact is produced.

Both observations are flagged as future hardening (config-validator task), neither blocks this merge.

## What this completes

Bug 2321 produced THREE INFO findings: S1 (fail-open missing artifact), S2 (fail-open on review crash), S3 (precedence divergence). All three are now closed:

- **S1 + S2** → task 2341 / PR #12 (Equipa) — merged
- **S3** → this PR

There is no longer any silently-divergent enablement code for the security-review feature. A future maintainer who changes the precedence chain can do so in **one** place.

## Test plan

- [x] `pytest tests/test_security_review_config.py` — 9/9 PASS
- [x] `pytest tests/test_dispatch_parallel_security_review.py` — 20/20 PASS (existing regression)
- [x] Full suite — 1567/1567 PASS
- [ ] Reviewer: confirm both call sites (`cli.py:run_mode_task`, `dispatch.py:run_parallel_tasks`) use the imported helper, not a local definition
- [ ] Reviewer: spot-check `equipa/config.py:is_security_review_enabled` precedence matches the pre-refactor inline chain
