### PR TITLE
fix(bash-security): per-segment check-4 evaluation + add single & to splitter (bug 2316 + S1)

### DIFF
--- a/equipa/bash_security.py
+++ b/equipa/bash_security.py
@@ -171,6 +171,115 @@ def _get_base_command(command: str) -> str:
     return parts[0] if parts else ""
 
 
+def _split_command_segments(command: str) -> list[str]:
+    """Split *command* on top-level ``;``, ``&&``, ``||``, ``|``.
+
+    Splits are made only at the top quoting/substitution level — operators
+    inside single or double quotes, ``$(...)`` substitutions, or backtick
+    substitutions are treated as literal characters. Empty segments are
+    dropped; surrounding whitespace is stripped from each returned segment.
+
+    Used by Check 4 (locale quoting) to evaluate the safe-base allowlist
+    per chained segment rather than only on the head command. See bug 2316.
+    """
+    segments: list[str] = []
+    buf: list[str] = []
+    in_single = False
+    in_double = False
+    paren_depth = 0  # $(...) depth, tracked outside single quotes
+    in_backtick = False
+    i = 0
+    n = len(command)
+
+    def flush() -> None:
+        seg = "".join(buf).strip()
+        if seg:
+            segments.append(seg)
+        buf.clear()
+
+    while i < n:
+        ch = command[i]
+        nxt = command[i + 1] if i + 1 < n else ""
+
+        if in_single:
+            buf.append(ch)
+            if ch == "'":
+                in_single = False
+            i += 1
+            continue
+
+        if in_backtick:
+            buf.append(ch)
+            if ch == "`":
+                in_backtick = False
+            i += 1
+            continue
+
+        # `$(` opens a substitution in both unquoted and double-quoted contexts.
+        if ch == "$" and nxt == "(":
+            paren_depth += 1
+            buf.append(ch)
+            buf.append(nxt)
+            i += 2
+            continue
+        if paren_depth > 0:
+            if ch == "(":
+                paren_depth += 1
+            elif ch == ")":
+                paren_depth -= 1
+            buf.append(ch)
+            i += 1
+            continue
+
+        if in_double:
+            if ch == '"':
+                in_double = False
+            buf.append(ch)
+            i += 1
+            continue
+
+        # Outside quotes / substitutions.
+        if ch == "'":
+            in_single = True
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == '"':
+            in_double = True
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == "`":
+            in_backtick = True
+            buf.append(ch)
+            i += 1
+            continue
+
+        # Top-level operators end the current segment.
+        if ch == ";":
+            flush()
+            i += 1
+            continue
+        if ch == "&" and nxt == "&":
+            flush()
+            i += 2
+            continue
+        if ch == "|" and nxt == "|":
+            flush()
+            i += 2
+            continue
+        if ch == "|":
+            flush()
+            i += 1
+            continue
+
+        buf.append(ch)
+        i += 1
+
+    flush()
+    return segments
+
+
 def _has_backslash_escaped_whitespace(command: str) -> bool:
     """Detect backslash-space or backslash-tab outside quotes."""
     in_single = False
@@ -650,12 +759,26 @@ def _check_obfuscated_flags(command: str, base_cmd: str) -> BashSecurityResult:
     # the pattern is the legitimate use case (passing localized search terms).
     # Loosen for task #2096-class false positives while keeping the block
     # active for cmd/eval/sh/bash/python/node/etc.
+    #
+    # Per-segment evaluation (bug 2316): split on top-level `;`/`&&`/`||`/`|`
+    # and evaluate the allowlist against EACH chained segment's own first
+    # word. Without this, a safe head (`git status; python -c $"x"`) would
+    # whitewash an exec primitive in a later segment.
     if re.search(r'\$"[^"]*"', command):
-        if base_cmd not in _LOCALE_QUOTING_SAFE_BASES:
-            return BashSecurityResult(
-                safe=False, check_id=CheckID.OBFUSCATED_FLAGS,
-                message="Command contains locale quoting ($\"...\") which can hide characters",
-            )
+        segments = _split_command_segments(command)
+        # Fall back to whole-command behavior when the splitter produced no
+        # segments (defensive — empty/whitespace-only input).
+        if not segments:
+            segments = [command]
+        for segment in segments:
+            if not re.search(r'\$"[^"]*"', segment):
+                continue
+            seg_base = _get_base_command(segment)
+            if seg_base not in _LOCALE_QUOTING_SAFE_BASES:
+                return BashSecurityResult(
+                    safe=False, check_id=CheckID.OBFUSCATED_FLAGS,
+                    message="Command contains locale quoting ($\"...\") which can hide characters",
+                )
 
     # Empty ANSI-C or locale quotes before dash: $''-exec or $""-exec
     if not skip_empty_quote_checks and re.search(r"""\$['\"]{2}\s*-""", command):

--- a/equipa/bash_security.py
+++ b/equipa/bash_security.py
@@ -264,6 +264,14 @@ def _split_command_segments(command: str) -> list[str]:
             flush()
             i += 2
             continue
+        if ch == "&":
+            # Single `&` is bash's background-process separator (cmd1 & cmd2).
+            # Attack-equivalent to `;` for per-segment check-4 purposes — see
+            # SECURITY-REVIEW-2316.md finding S1. Must come AFTER the `&&`
+            # check so the two-char operator is detected first.
+            flush()
+            i += 1
+            continue
         if ch == "|" and nxt == "|":
             flush()
             i += 2

--- a/tests/test_bash_security.py
+++ b/tests/test_bash_security.py
@@ -1040,6 +1040,44 @@ class TestDeveloperLoosens:
         result = check_bash_command(r'bash -c $"x"')
         assert not result.safe
 
+    # ---- Bug 2316: check-4 must evaluate the safe-base allowlist
+    #               per chained command segment, not gate on head base_cmd.
+
+    def test_chained_exec_after_safe_base_blocks(self) -> None:
+        """`git status; python -c $"x"` must block — python segment is exec."""
+        result = check_bash_command(r'git status; python -c $"x"')
+        assert not result.safe, (
+            "expected block on chained python segment carrying locale quoting"
+        )
+
+    def test_chained_eval_after_safe_base_blocks(self) -> None:
+        """`git status && eval $"x"` must block — eval segment is exec."""
+        result = check_bash_command(r'git status && eval $"x"')
+        assert not result.safe
+
+    def test_piped_exec_after_safe_base_blocks(self) -> None:
+        """`git status | python -c $"x"` must block — python segment is exec."""
+        result = check_bash_command(r'git status | python -c $"x"')
+        assert not result.safe
+
+    def test_chained_safe_after_safe_passes(self) -> None:
+        """`git status; grep -r $"foo" .` passes — both segments use safe bases."""
+        cmd = r'git status; grep -r $"foo" .'
+        result = check_bash_command(cmd)
+        assert result.safe, f"expected safe: {cmd} -> {result.message}"
+
+    def test_single_segment_safe_still_passes(self) -> None:
+        """Single-segment safe-base case (bug 2310) still passes."""
+        cmd = 'git commit -m "fix: $\\"x\\""'
+        result = check_bash_command(cmd)
+        assert result.safe, f"expected safe: {cmd} -> {result.message}"
+
+    def test_quoted_pipe_inside_string_not_split(self) -> None:
+        """A `|` inside a double-quoted argument must NOT split into segments."""
+        cmd = 'git commit -m "this has | in message"'
+        result = check_bash_command(cmd)
+        assert result.safe, f"expected safe: {cmd} -> {result.message}"
+
     # ---- Check 6: variables in pipes/redirects (loop counters) ---- #
 
     @pytest.mark.parametrize("cmd", [

--- a/tests/test_bash_security.py
+++ b/tests/test_bash_security.py
@@ -1049,16 +1049,30 @@ class TestDeveloperLoosens:
         assert not result.safe, (
             "expected block on chained python segment carrying locale quoting"
         )
+        assert result.check_id == CheckID.OBFUSCATED_FLAGS, (
+            f"expected check 4 to fire on locale-quoting; got {result.check_id}"
+        )
 
     def test_chained_eval_after_safe_base_blocks(self) -> None:
         """`git status && eval $"x"` must block — eval segment is exec."""
         result = check_bash_command(r'git status && eval $"x"')
         assert not result.safe
+        assert result.check_id == CheckID.OBFUSCATED_FLAGS
 
     def test_piped_exec_after_safe_base_blocks(self) -> None:
         """`git status | python -c $"x"` must block — python segment is exec."""
         result = check_bash_command(r'git status | python -c $"x"')
         assert not result.safe
+        assert result.check_id == CheckID.OBFUSCATED_FLAGS
+
+    def test_backgrounded_exec_after_safe_base_blocks(self) -> None:
+        """Bug 2316 S1: `git status & python -c $"x"` must block — `&` is
+        bash's background-process separator and attack-equivalent to `;`."""
+        result = check_bash_command(r'git status & python -c $"x"')
+        assert not result.safe, (
+            "expected block on backgrounded python segment carrying locale quoting"
+        )
+        assert result.check_id == CheckID.OBFUSCATED_FLAGS
 
     def test_chained_safe_after_safe_passes(self) -> None:
         """`git status; grep -r $"foo" .` passes — both segments use safe bases."""


### PR DESCRIPTION
**Closes TheForge bug 2316** + addresses S1+S2 findings from SECURITY-REVIEW-2316.md inline.

## What this fixes

Check-4 (locale-quoting `$"..."`) was structurally bypassable: the head base-command determined whether the WHOLE command line was exempt from the locale-quoting block. So:

```
git status; python -c $"x"        → passed (WRONG)
git status && eval $"x"           → passed (WRONG)
git status | python -c $"x"       → passed (WRONG)
git status & python -c $"x"       → passed (WRONG — S1 finding)
```

The fix splits the command line on top-level operators (`;`, `&&`, `||`, `|`, **`&`** post-review) and runs the safe-base allowlist decision PER SEGMENT against that segment's own first word.

## Diff (3 commits, 2 files, +188/-5)

| File | Lines | Purpose |
|---|---:|---|
| `equipa/bash_security.py` | +146/-5 | `_split_command_segments` hand-written linear parser respecting quotes/`$()`/backticks; check-4 loops per segment |
| `tests/test_bash_security.py` | +42 | 7 regression tests covering the 4 BLOCK cases + 3 PASS cases |

## Security review (saved as `SECURITY-REVIEW-2316.md`)

Reviewer (agent): semgrep `p/security-audit` + `p/python` (200 rules, 0 findings) + manual review + dynamic probing.

- **0 CRITICAL, 0 HIGH, 0 MEDIUM**
- **S1 LOW (fixed in this PR)** — original splitter handled `;`/`&&`/`||`/`|` but NOT single `&`. Reviewer verified `git status & python -c $"x"` returned `safe=True`. Same fix shape as the bug itself: added single-`&` arm to the operator chain (must come AFTER `&&` check). Added `test_backgrounded_exec_after_safe_base_blocks`.
- **S2 INFO (fixed in this PR)** — the three MUST-BLOCK tests asserted only `not result.safe`. If check-4 were ever disabled entirely, the tests would still pass (the chained `python -c $"x"` is also blocked by check 14 exec primitives). Pinned all three to `CheckID.OBFUSCATED_FLAGS`.
- **S3 INFO (deferred)** — dead defensive fallback `if not segments: segments = [command]`. Unreachable today (caught by check 1 earlier); cost-free defense against future check reordering. Left as-is.
- **S4 INFO (deferred)** — splitter doesn't honor `\"` escapes inside double-quoted strings; over-splits, which causes false-positive blocks not bypasses. Direction of bias is safe. Could matter if `_split_command_segments` is reused by future checks that scan segment content for tokens INSIDE quoted regions — log for future hardening.

**Verdict: APPROVE**.

## Test results

```
$ python3 -m pytest tests/test_bash_security.py -q
248 passed in 0.80s
```

(Was 247 before S1 fix; +1 for `test_backgrounded_exec_after_safe_base_blocks`.)

## What this completes

Closes the last known false-negative class for check-4: composed commands of the form `<safe-base> <op> <exec-primitive> $"..."` no longer escape the locale-quoting block. The locale-quoting threat itself remains low-severity (acknowledged in surrounding code comments), but defense-in-depth now matches the spec.

## Test plan

- [x] `pytest tests/test_bash_security.py` — 248/248 PASS
- [x] Manual probe: `git status & python -c $"x"` now returns `safe=False` with `CheckID.OBFUSCATED_FLAGS`
- [x] Manual probe: `git status; grep -r $"foo" .` (both safe-base) still PASSES
- [x] Manual probe: `git commit -m "this has | in message"` (quoted pipe) still PASSES
- [ ] Reviewer: spot-check the `&` arm comes AFTER the `&&` arm in `_split_command_segments` (otherwise `&&` would be eaten as two consecutive single-`&`)

## Out of scope

- S3 / S4 INFO findings (deferred per review)
- Adding `\"`-escape tracking to the double-quote state machine (S4 future hardening)
