### PR TITLE
feat: worktree isolation — Phase 1 (module), Phase 2 (merge lock), Phase 3 (cleanup CLI)

### DIFF
--- a/db_migrate.py
+++ b/db_migrate.py
@@ -30,7 +30,7 @@ from datetime import datetime
 from pathlib import Path
 
 # The schema version that matches the current schema.sql
-CURRENT_VERSION = 11
+CURRENT_VERSION = 12
 
 
 # ============================================================
@@ -844,6 +844,50 @@ def migrate_v10_to_v11(conn):
     conn.commit()
 
 
+def migrate_v11_to_v12(conn):
+    """Add worktree isolation tracking (v11 -> v12).
+
+    Adds the ``worktrees`` table and a ``worktree_path`` column on
+    ``agent_runs`` to support git-worktree-isolated agent dispatch.
+    See planning/worktree-isolation.md and Equipa task #215.
+
+    The ``worktrees`` table tracks one row per worktree-isolated dispatch:
+      - ``status`` lifecycle: active -> merged | failed | conflict | abandoned
+      - ``path`` is absolute; the worktree lives at
+        ``<project_dir>/forge_worktrees/<codename>-task-<id>/``
+      - ``branch`` is always ``forge-task-<task_id>`` in Phase 1
+
+    The ``agent_runs.worktree_path`` column is redundant with the join via
+    ``task_id`` but kept for direct querying during forensics.
+    """
+    try:
+        conn.execute(
+            "ALTER TABLE agent_runs ADD COLUMN worktree_path TEXT"
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass  # Column already exists
+
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS worktrees (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id INTEGER NOT NULL,
+            project_id INTEGER NOT NULL,
+            path TEXT NOT NULL,
+            branch TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            ended_at DATETIME,
+            FOREIGN KEY (task_id) REFERENCES tasks(id),
+            FOREIGN KEY (project_id) REFERENCES projects(id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_worktrees_status ON worktrees(status);
+        CREATE INDEX IF NOT EXISTS idx_worktrees_task ON worktrees(task_id);
+        CREATE INDEX IF NOT EXISTS idx_worktrees_project ON worktrees(project_id);
+    """)
+    conn.commit()
+
+
 # Migration registry: version -> (description, function)
 MIGRATIONS = {
     1: ("Baseline schema stamp (v0 -> v1)", migrate_v0_to_v1),
@@ -857,6 +901,7 @@ MIGRATIONS = {
     9: ("Task Flow tables (v8 -> v9)", migrate_v8_to_v9),
     10: ("Paperclip config version tables (v9 -> v10)", migrate_v9_to_v10),
     11: ("Paperclip agent_sessions table (v10 -> v11)", migrate_v10_to_v11),
+    12: ("Worktree isolation tracking (v11 -> v12)", migrate_v11_to_v12),
 }
 
 

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -30,6 +30,7 @@ from equipa.constants import (
     THEFORGE_DB,
 )
 from equipa.agent_runner import build_cli_command, run_agent_streaming, run_agent_with_retries
+from equipa.worktree_manager import TaskWorkspace
 from equipa.checkpoints import load_checkpoint
 from equipa.db import record_agent_run, update_task_status
 from equipa.dispatch import (
@@ -484,6 +485,11 @@ def _build_arg_parser() -> argparse.ArgumentParser:
                         help=f"Agent role (available: {', '.join(_available_roles)}) (default: developer)")
     parser.add_argument("--retries", type=int, default=DEFAULT_MAX_RETRIES, help=f"Max retry attempts (default: {DEFAULT_MAX_RETRIES})")
     parser.add_argument("--dev-test", action="store_true", help="Enable Dev+Tester iteration loop mode")
+    parser.add_argument("--worktree", action="store_true",
+                        help="Run the task in an isolated git worktree (forge_worktrees/<codename>-task-<id>). "
+                             "Commits land on branch forge-task-<id>; on success, merged back to the project's "
+                             "main branch and the worktree is destroyed. On failure, worktree retained for inspection. "
+                             "Single-task path only; --tasks A,B parallel dispatch already isolates.")
     parser.add_argument("--security-review", action="store_true", default=None,
                         help="Run security review after dev-test passes (default: from dispatch config)")
     parser.add_argument("--provider", choices=["claude", "ollama"], default=None,
@@ -969,130 +975,137 @@ async def run_mode_task(args: argparse.Namespace) -> None:
 
     # --- Execute ---
 
-    if args.dev_test:
-        # Dev+Tester iteration loop (Phase 2) with autoresearch retry
-        print(f"\nStarting Dev+Test loop (max {MAX_DEV_TEST_CYCLES} cycles)...")
+    async with TaskWorkspace(task["id"], project_dir, isolate=getattr(args, "worktree", False)) as ws:
+        project_dir = ws.path  # substitute worktree path when isolation is active
 
-        # Autoresearch config
-        dc = getattr(args, "dispatch_config", None) or {}
-        autoresearch_on = is_feature_enabled(dc, "autoresearch")
-        max_retries = dc.get("autoresearch_max_retries", 3) if autoresearch_on else 0
-        retry_count = 0
-        attempt_reflections: list[str] = []
+        if args.dev_test:
+            # Dev+Tester iteration loop (Phase 2) with autoresearch retry
+            print(f"\nStarting Dev+Test loop (max {MAX_DEV_TEST_CYCLES} cycles)...")
 
-        while True:
-            result, cycles, outcome = await run_dev_test_loop(
-                task, project_dir, project_context, args,
-            )
+            # Autoresearch config
+            dc = getattr(args, "dispatch_config", None) or {}
+            autoresearch_on = is_feature_enabled(dc, "autoresearch")
+            max_retries = dc.get("autoresearch_max_retries", 3) if autoresearch_on else 0
+            retry_count = 0
+            attempt_reflections: list[str] = []
 
-            # Success - break out
-            if outcome in ("tests_passed", "no_tests", "early_completed_no_changes"):
-                break
-
-            # Capture reflection from the failed attempt for cross-attempt memory
-            attempt_reflections.append(
-                _build_dispatch_attempt_reflection(
-                    retry_count + 1, outcome, cycles, result,
+            while True:
+                result, cycles, outcome = await run_dev_test_loop(
+                    task, project_dir, project_context, args,
                 )
-            )
 
-            # Not retriable or exhausted
-            if not autoresearch_on or retry_count >= max_retries:
-                if retry_count > 0:
-                    print(f"  [Autoresearch] Exhausted {retry_count}/{max_retries} retries "
-                          f"for task #{task['id']}. Final outcome: {outcome}")
-                break
+                # Success - break out
+                if outcome in ("tests_passed", "no_tests", "early_completed_no_changes"):
+                    break
 
-            retry_count += 1
-            print(f"  [Autoresearch] Task #{task['id']} failed ({outcome}). "
-                  f"Retry {retry_count}/{max_retries}...")
+                # Capture reflection from the failed attempt for cross-attempt memory
+                attempt_reflections.append(
+                    _build_dispatch_attempt_reflection(
+                        retry_count + 1, outcome, cycles, result,
+                    )
+                )
 
-            # Clean up failed branch and reset task (with reflection memory)
-            await cleanup_failed_attempt(
-                task["id"], project_dir, attempt_reflections,
-            )
+                # Not retriable or exhausted
+                if not autoresearch_on or retry_count >= max_retries:
+                    if retry_count > 0:
+                        print(f"  [Autoresearch] Exhausted {retry_count}/{max_retries} retries "
+                              f"for task #{task['id']}. Final outcome: {outcome}")
+                    break
 
-        # Post-task telemetry (DB update, ForgeSmith recording, quality scoring, reflexion, MemRL)
-        task_role = task.get("role") or "developer"
-        await _post_task_telemetry(
-            task, result, outcome, role=task_role,
-            model=get_role_model(task_role, args, task=task),
-            max_turns=get_role_turns(task_role, args, task=task),
-            cycle_number=cycles,
-            dispatch_config=getattr(args, "dispatch_config", None))
+                retry_count += 1
+                print(f"  [Autoresearch] Task #{task['id']} failed ({outcome}). "
+                      f"Retry {retry_count}/{max_retries}...")
 
-        # Optional security review after successful dev-test
-        # CLI --security-review flag takes precedence, then dispatch config top-level key,
-        # then features.security_review flag (all must agree for review to run)
-        dc = getattr(args, "dispatch_config", None) or {}
-        security_review_enabled = args.security_review
-        if security_review_enabled is None:
-            security_review_enabled = dc.get("security_review", False)
-        # Feature flag can disable even if top-level key is True
-        if not is_feature_enabled(dc, "security_review"):
-            security_review_enabled = False
+                # Clean up failed branch and reset task (with reflection memory)
+                await cleanup_failed_attempt(
+                    task["id"], project_dir, attempt_reflections,
+                )
 
-        if security_review_enabled and outcome in ("tests_passed", "no_tests"):
-            await run_security_review(task, project_dir, project_context, args)
+            # Post-task telemetry (DB update, ForgeSmith recording, quality scoring, reflexion, MemRL)
+            task_role = task.get("role") or "developer"
+            await _post_task_telemetry(
+                task, result, outcome, role=task_role,
+                model=get_role_model(task_role, args, task=task),
+                max_turns=get_role_turns(task_role, args, task=task),
+                cycle_number=cycles,
+                dispatch_config=getattr(args, "dispatch_config", None))
 
-        # Verify the task status in TheForge
-        verified, verify_msg = verify_task_updated(task["id"])
+            ws.set_success(outcome in ("tests_passed", "no_tests", "early_completed_no_changes"))
 
-        # Print loop summary
-        print_dev_test_summary(task, result, cycles, outcome, verified, verify_msg)
+            # Optional security review after successful dev-test
+            # CLI --security-review flag takes precedence, then dispatch config top-level key,
+            # then features.security_review flag (all must agree for review to run)
+            dc = getattr(args, "dispatch_config", None) or {}
+            security_review_enabled = args.security_review
+            if security_review_enabled is None:
+                security_review_enabled = dc.get("security_review", False)
+            # Feature flag can disable even if top-level key is True
+            if not is_feature_enabled(dc, "security_review"):
+                security_review_enabled = False
 
-    else:
-        # Single-agent mode (Phase 1 — with model tiering)
-        use_streaming = args.role not in EARLY_TERM_EXEMPT_ROLES
-        role_turns_max = get_role_turns(args.role, args, task=task)
-        role_model = get_role_model(args.role, args, task=task)
-        # Dynamic budget for single-agent mode
-        role_turns_allocated, _ = calculate_dynamic_budget(role_turns_max)
-        system_prompt = build_system_prompt(
-            task, project_context, project_dir, role=args.role,
-            dispatch_config=getattr(args, "dispatch_config", None),
-            max_turns=role_turns_allocated,
-        )
-        print(f"Dynamic budget: {role_turns_allocated}/{role_turns_max} turns")
-        with build_cli_command(
-            system_prompt, project_dir, role_turns_allocated, role_model, role=args.role,
-            streaming=use_streaming,
-        ) as cmd:
-            print(f"System prompt: {len(system_prompt)} chars, ~{estimate_tokens(system_prompt)} tokens")
+            if security_review_enabled and outcome in ("tests_passed", "no_tests"):
+                await run_security_review(task, project_dir, project_context, args)
 
-            print(f"\nStarting {args.role} agent...")
-            if use_streaming:
-                # Streaming mode with early termination — no retries (kill is intentional)
-                result = await run_agent_streaming(cmd, role=args.role)
-                attempts = 1
-            else:
-                result, attempts = await run_agent_with_retries(cmd, task, args.retries)
+            # Verify the task status in TheForge
+            verified, verify_msg = verify_task_updated(task["id"])
 
-        # Tag result with dynamic budget info for telemetry
-        result["turns_allocated"] = role_turns_allocated
-        result["turns_max"] = role_turns_max
+            # Print loop summary
+            print_dev_test_summary(task, result, cycles, outcome, verified, verify_msg)
 
-        # Determine outcome
-        if result.get("early_terminated"):
-            single_outcome = "early_terminated"
-        elif result["success"]:
-            single_outcome = "tests_passed"
         else:
-            single_outcome = "developer_failed"
+            # Single-agent mode (Phase 1 — with model tiering)
+            use_streaming = args.role not in EARLY_TERM_EXEMPT_ROLES
+            role_turns_max = get_role_turns(args.role, args, task=task)
+            role_model = get_role_model(args.role, args, task=task)
+            # Dynamic budget for single-agent mode
+            role_turns_allocated, _ = calculate_dynamic_budget(role_turns_max)
+            system_prompt = build_system_prompt(
+                task, project_context, project_dir, role=args.role,
+                dispatch_config=getattr(args, "dispatch_config", None),
+                max_turns=role_turns_allocated,
+            )
+            print(f"Dynamic budget: {role_turns_allocated}/{role_turns_max} turns")
+            with build_cli_command(
+                system_prompt, project_dir, role_turns_allocated, role_model, role=args.role,
+                streaming=use_streaming,
+            ) as cmd:
+                print(f"System prompt: {len(system_prompt)} chars, ~{estimate_tokens(system_prompt)} tokens")
 
-        # Post-task telemetry
-        await _post_task_telemetry(
-            task, result, single_outcome, role=args.role,
-            model=role_model, max_turns=role_turns_max,
-            dispatch_config=getattr(args, "dispatch_config", None))
+                print(f"\nStarting {args.role} agent...")
+                if use_streaming:
+                    # Streaming mode with early termination — no retries (kill is intentional)
+                    result = await run_agent_streaming(cmd, role=args.role)
+                    attempts = 1
+                else:
+                    result, attempts = await run_agent_with_retries(cmd, task, args.retries)
 
-        # Verify the task status in TheForge
-        verified, verify_msg = verify_task_updated(task["id"])
+            # Tag result with dynamic budget info for telemetry
+            result["turns_allocated"] = role_turns_allocated
+            result["turns_max"] = role_turns_max
 
-        # Print summary
-        print_summary(task, result, verified, verify_msg)
-        if attempts > 1:
-            print(f"  Attempts: {attempts}/{args.retries}")
+            # Determine outcome
+            if result.get("early_terminated"):
+                single_outcome = "early_terminated"
+            elif result["success"]:
+                single_outcome = "tests_passed"
+            else:
+                single_outcome = "developer_failed"
+
+            ws.set_success(single_outcome == "tests_passed")
+
+            # Post-task telemetry
+            await _post_task_telemetry(
+                task, result, single_outcome, role=args.role,
+                model=role_model, max_turns=role_turns_max,
+                dispatch_config=getattr(args, "dispatch_config", None))
+
+            # Verify the task status in TheForge
+            verified, verify_msg = verify_task_updated(task["id"])
+
+            # Print summary
+            print_summary(task, result, verified, verify_msg)
+            if attempts > 1:
+                print(f"  Attempts: {attempts}/{args.retries}")
 
 
 # --- Mode Dispatcher ---

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -456,6 +456,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
                         help="Regenerate skill_manifest.json with SHA-256 hashes of all prompt/skill files")
     group.add_argument("--mcp-server", action="store_true",
                         help="Run as MCP server (JSON-RPC over stdio)")
+    group.add_argument("--cleanup-worktrees", action="store_true",
+                        help="Batch cleanup failed/abandoned worktrees. "
+                             "Stashes uncommitted work, removes directories, deletes branches. "
+                             "Use --dry-run to preview. Use --only-project to scope.")
     group.add_argument("--config-cmd", choices=["snapshot", "list", "diff", "rollback"],
                         metavar="VERB",
                         help="Config-versioning subcommand: snapshot|list|diff|rollback")
@@ -648,6 +652,45 @@ async def run_mode_config(args: argparse.Namespace) -> None:
 
     print(f"ERROR: unknown config verb: {verb}")
     sys.exit(1)
+
+
+async def run_mode_cleanup_worktrees(args: argparse.Namespace) -> None:
+    """Batch cleanup of failed/abandoned worktrees."""
+    from equipa.worktree_manager import cleanup_all_stale, list_stale
+
+    project_id = args.only_project[0] if args.only_project else None
+
+    stale = list_stale(project_id)
+    if not stale:
+        print("No stale worktrees found.")
+        return
+
+    print(f"\nStale worktrees ({len(stale)} found):")
+    print(f"{'Task':>6}  {'Status':<10}  {'Branch':<25}  {'Created':<20}  {'Disk':<5}  Path")
+    print("-" * 100)
+    for r in stale:
+        disk = "YES" if Path(r.path).exists() else "no"
+        created = r.created_at[:19] if r.created_at else "?"
+        print(f"#{r.task_id:>5}  {r.status:<10}  {r.branch:<25}  {created:<20}  {disk:<5}  {r.path}")
+
+    if args.dry_run:
+        print(f"\n[DRY RUN] Would clean up {len(stale)} worktree(s). No changes made.")
+        return
+
+    if not args.yes:
+        response = input(f"\nClean up {len(stale)} worktree(s)? (y/n): ").strip().lower()
+        if response != "y":
+            print("Aborted.")
+            return
+
+    results = await cleanup_all_stale(project_id)
+
+    successes = sum(1 for _, ok, _ in results if ok)
+    failures = len(results) - successes
+    for _, ok, msg in results:
+        status = "OK" if ok else "FAIL"
+        print(f"  [{status}] {msg}")
+    print(f"\nCleanup complete: {successes} cleaned, {failures} failed")
 
 
 async def run_mode_regenerate_manifest(args: argparse.Namespace) -> None:
@@ -1135,6 +1178,8 @@ def _select_mode_handler(args: argparse.Namespace) -> "callable":
     """
     if args.mcp_server:
         return run_mode_mcp_server
+    if getattr(args, "cleanup_worktrees", False):
+        return run_mode_cleanup_worktrees
     if getattr(args, "config_cmd", None):
         return run_mode_config
     if args.regenerate_manifest:

--- a/equipa/dispatch.py
+++ b/equipa/dispatch.py
@@ -49,6 +49,14 @@ from equipa.db import (
 )
 from equipa.hooks import fire_async as fire_hook
 from equipa.git_ops import _is_git_repo, git_run_async
+from equipa.worktree_manager import (
+    WorktreeError,
+    create as create_worktree,
+    destroy as destroy_worktree,
+    mark_conflict as mark_worktree_conflict,
+    mark_failed as mark_worktree_failed,
+    merge_back as merge_worktree_back,
+)
 from equipa.lessons import update_injected_episode_q_values_for_task
 from equipa.loops import (
     run_dev_test_loop,
@@ -1003,328 +1011,13 @@ def parse_task_ids(task_str: str) -> list[int]:
     return ids
 
 
-def _copy_hooks_to_worktree(main_repo_dir: str, worktree_dir: str) -> None:
-    """Copy git hooks from the main repo into a worktree.
-
-    Worktrees do NOT inherit .git/hooks from the parent repo. This means
-    pre-commit hooks (like plugin boundary checks) won't fire in worktrees
-    unless we explicitly copy them.
-    """
-    import shutil
-    main_hooks = Path(main_repo_dir) / ".git" / "hooks"
-    if not main_hooks.is_dir():
-        return
-
-    # Worktree .git is a file pointing to the main repo's worktree dir.
-    # The actual hooks dir for a worktree is in the main repo at:
-    # .git/worktrees/<worktree-name>/hooks (doesn't exist by default)
-    # But we can also just copy hooks into the worktree and configure.
-    #
-    # Simplest approach: copy the pre-commit hook and any other hooks
-    # to the worktree's common hooks dir.
-    wt_git_path = Path(worktree_dir) / ".git"
-    if wt_git_path.is_file():
-        # .git is a file like "gitdir: /path/to/.git/worktrees/task-123"
-        gitdir = wt_git_path.read_text().strip().replace("gitdir: ", "")
-        wt_hooks = Path(gitdir) / "hooks"
-        wt_hooks.mkdir(exist_ok=True)
-        for hook in main_hooks.iterdir():
-            if hook.is_file() and not hook.name.endswith(".sample"):
-                dest = wt_hooks / hook.name
-                shutil.copy2(str(hook), str(dest))
-    # Also copy .plugin-boundary-markers if it exists (for the pre-commit hook)
-    markers_src = Path(main_repo_dir) / ".plugin-boundary-markers"
-    markers_dst = Path(worktree_dir) / ".plugin-boundary-markers"
-    if markers_src.exists() and not markers_dst.exists():
-        shutil.copy2(str(markers_src), str(markers_dst))
-
-
-async def _create_isolation_worktrees(
-    tasks: list[dict],
-    project_dir: str,
-    worktree_base: Path,
-) -> dict[int, str]:
-    """Create per-task git worktrees for filesystem isolation.
-
-    Returns a map of task_id -> worktree directory path. Tasks for which
-    worktree creation fails are omitted from the returned map (they will
-    fall back to sharing project_dir).
-
-    Uses ``git_run_async`` so the per-task git invocations do not block
-    the event loop while parallel task dispatch is queued.
-    """
-    worktree_dirs: dict[int, str] = {}
-    worktree_base.mkdir(exist_ok=True)
-    for t in tasks:
-        task_id = t["id"]
-        branch_name = f"forge-task-{task_id}"
-        wt_path = worktree_base / f"task-{task_id}"
-        try:
-            if wt_path.exists():
-                await git_run_async(
-                    ["worktree", "remove", "--force", str(wt_path)],
-                    project_dir, timeout=30,
-                )
-            add_res = await git_run_async(
-                ["worktree", "add", "-b", branch_name, str(wt_path), "HEAD"],
-                project_dir, timeout=60,
-            )
-            if add_res.returncode != 0:
-                # Fallback: branch may already exist — delete and retry.
-                await git_run_async(
-                    ["branch", "-D", branch_name], project_dir, timeout=10,
-                )
-                retry_res = await git_run_async(
-                    ["worktree", "add", "-b", branch_name, str(wt_path), "HEAD"],
-                    project_dir, timeout=60,
-                )
-                if retry_res.returncode != 0:
-                    err_preview = (
-                        retry_res.stderr[:200] if retry_res.stderr
-                        else f"rc={retry_res.returncode}"
-                    )
-                    print(
-                        f"  [Isolation] WARNING: Could not create worktree for "
-                        f"task #{task_id}, using shared dir "
-                        f"(retry failed: {err_preview})"
-                    )
-                    continue
-                worktree_dirs[task_id] = str(wt_path)
-                _copy_hooks_to_worktree(project_dir, str(wt_path))
-                print(f"  [Isolation] Task #{task_id} -> {wt_path.name} (retry)")
-            else:
-                worktree_dirs[task_id] = str(wt_path)
-                _copy_hooks_to_worktree(project_dir, str(wt_path))
-                print(f"  [Isolation] Task #{task_id} -> {wt_path.name}")
-        except (subprocess.SubprocessError, OSError) as e:
-            print(
-                f"  [Isolation] WARNING: Worktree creation errored for "
-                f"task #{task_id}: {e}"
-            )
-    return worktree_dirs
-
-
-async def _merge_task_branch(project_dir: str, task_id: int, branch_name: str) -> bool:
-    """Merge a single task branch into the main repo's current branch.
-
-    Returns True if the merge succeeded (HEAD advanced), False otherwise.
-    All failures are logged to stdout — the function NEVER swallows errors
-    silently. On any failure path, the branch is preserved (not deleted).
-
-    Uses ``git_run_async`` so the 6-12 git invocations per merge do not
-    block the event loop.
-    """
-    try:
-        current = await git_run_async(
-            ["branch", "--show-current"], project_dir, timeout=10,
-        )
-        current_branch = current.stdout.strip()
-        if not current_branch:
-            for candidate in ["master", "main"]:
-                check = await git_run_async(
-                    ["show-ref", "--verify", f"refs/heads/{candidate}"],
-                    project_dir, timeout=10,
-                )
-                if check.returncode == 0:
-                    await git_run_async(
-                        ["checkout", candidate], project_dir, timeout=30,
-                    )
-                    current_branch = candidate
-                    break
-        print(f"  [Isolation] Merging on branch: {current_branch} in {project_dir}")
-
-        pre_head_res = await git_run_async(
-            ["rev-parse", "HEAD"], project_dir, timeout=10,
-        )
-        pre_head = pre_head_res.stdout.strip()
-
-        ahead = await git_run_async(
-            ["log", "--oneline", f"HEAD..{branch_name}"], project_dir, timeout=15,
-        )
-        if not ahead.stdout.strip():
-            print(
-                f"  [Isolation] Task #{task_id}: branch '{branch_name}' has "
-                f"NO commits ahead of HEAD — skipping merge"
-            )
-            return False
-
-        commits_ahead = len(ahead.stdout.strip().split("\n"))
-        print(
-            f"  [Isolation] Task #{task_id}: branch '{branch_name}' has "
-            f"{commits_ahead} commit(s) to merge"
-        )
-
-        stash_result = await git_run_async(
-            ["stash"], project_dir, timeout=30,
-        )
-        had_stash = "Saved working directory" in stash_result.stdout
-
-        try:
-            merge_result = await git_run_async(
-                ["merge", "--no-edit", branch_name], project_dir, timeout=60,
-            )
-            post_head_res = await git_run_async(
-                ["rev-parse", "HEAD"], project_dir, timeout=10,
-            )
-            post_head = post_head_res.stdout.strip()
-
-            if merge_result.returncode == 0 and post_head != pre_head:
-                print(
-                    f"  [Isolation] Merged task #{task_id} into main "
-                    f"({pre_head[:8]} -> {post_head[:8]})"
-                )
-                return True
-            if merge_result.returncode == 0 and post_head == pre_head:
-                print(
-                    f"  [Isolation] WARNING: Merge returned 0 for task "
-                    f"#{task_id} but HEAD unchanged ({pre_head[:8]})"
-                )
-                print(f"  [Isolation] Merge stdout: {merge_result.stdout[:200]}")
-                return False
-
-            # Conflict path: try rebase-then-merge.
-            await git_run_async(
-                ["merge", "--abort"], project_dir, timeout=15,
-            )
-            rebase_result = await git_run_async(
-                ["rebase", "HEAD", branch_name], project_dir, timeout=60,
-            )
-            if rebase_result.returncode != 0:
-                await git_run_async(
-                    ["rebase", "--abort"], project_dir, timeout=15,
-                )
-                print(
-                    f"  [Isolation] Merge FAILED for task #{task_id}: "
-                    f"{merge_result.stderr[:200]}"
-                )
-                print(f"  [Isolation] Branch '{branch_name}' PRESERVED")
-                return False
-
-            merge2 = await git_run_async(
-                ["merge", "--no-edit", branch_name], project_dir, timeout=60,
-            )
-            if merge2.returncode == 0:
-                print(f"  [Isolation] Merged task #{task_id} (after rebase)")
-                return True
-            await git_run_async(
-                ["merge", "--abort"], project_dir, timeout=15,
-            )
-            print(
-                f"  [Isolation] Merge FAILED for task #{task_id} "
-                f"(conflict after rebase)"
-            )
-            print(f"  [Isolation] Branch '{branch_name}' PRESERVED")
-            return False
-        finally:
-            if had_stash:
-                await git_run_async(
-                    ["stash", "pop"], project_dir, timeout=30,
-                )
-    except (subprocess.SubprocessError, OSError) as e:
-        # Explicit error log — do NOT silently swallow. Branch is preserved
-        # because we did not add it to the merged set.
-        print(f"  [Isolation] Merge error for task #{task_id}: {e}")
-        print(f"  [Isolation] Branch '{branch_name}' PRESERVED (merge errored)")
-        return False
-
-
-async def _stash_uncommitted_in_worktree(
-    wt_path: str,
-    task_id: int,
-    branch_name: str,
-) -> None:
-    """Stash any uncommitted changes inside ``wt_path`` onto its branch.
-
-    Runs inside the worktree itself so the stash lands on ``branch_name``'s
-    HEAD. Includes untracked files (``-u``) so newly-created agent files
-    are preserved. Stash message is tagged so it can be located later by
-    rescue tooling: ``equipa-early-term task-<id>``.
-
-    Silent failure paths (missing git, no changes, locked index) are
-    logged but never raised — cleanup must continue even if the stash
-    cannot be saved.
-    """
-    if not Path(wt_path).exists():
-        return
-    try:
-        status = await git_run_async(
-            ["status", "--porcelain"], wt_path, timeout=15,
-        )
-        if status.returncode != 0 or not status.stdout.strip():
-            return
-        stash_msg = f"equipa-early-term task-{task_id} branch-{branch_name}"
-        result = await git_run_async(
-            ["stash", "push", "-u", "-m", stash_msg],
-            wt_path, timeout=30,
-        )
-        if result.returncode == 0 and "No local changes" not in result.stdout:
-            print(
-                f"  [Isolation] Task #{task_id}: stashed uncommitted work "
-                f"on '{branch_name}' as '{stash_msg}'"
-            )
-    except (subprocess.SubprocessError, OSError) as e:
-        print(
-            f"  [Isolation] Could not stash uncommitted work for task "
-            f"#{task_id} on '{branch_name}': {e}"
-        )
-
-
-async def _cleanup_worktrees(
-    project_dir: str,
-    worktree_dirs: dict[int, str],
-    merged_tasks: set[int],
-    worktree_base: Path,
-) -> None:
-    """Remove worktree directories; delete merged branches; preserve unmerged.
-
-    Per-task failures are logged (not silently swallowed) so that data-loss
-    investigations have evidence of which step failed.
-
-    Uses ``git_run_async`` so the per-task ``git worktree remove`` and
-    ``git branch -D`` calls do not block the event loop.
-    """
-    for task_id, wt_path in worktree_dirs.items():
-        branch_name = f"forge-task-{task_id}"
-        try:
-            state_file = Path(wt_path) / ".forge-state.json"
-            if state_file.exists():
-                state_file.unlink()
-            # Preserve uncommitted work on UNMERGED branches before the
-            # `git worktree remove --force` discards the working tree.
-            # Without this, an early_terminated agent that wrote 32 turns of
-            # edits but did not commit loses everything when the worktree is
-            # torn down. Stash on the worktree's own branch (HEAD) so the
-            # work can be salvaged later by checking out the branch and
-            # running `git stash pop`.
-            if task_id not in merged_tasks:
-                await _stash_uncommitted_in_worktree(
-                    wt_path, task_id, branch_name,
-                )
-            await git_run_async(
-                ["worktree", "remove", "--force", wt_path],
-                project_dir, timeout=30,
-            )
-            if task_id in merged_tasks:
-                await git_run_async(
-                    ["branch", "-D", branch_name], project_dir, timeout=10,
-                )
-            else:
-                print(
-                    f"  [Isolation] Keeping branch '{branch_name}' "
-                    f"(unmerged work)"
-                )
-        except (subprocess.SubprocessError, OSError) as e:
-            print(
-                f"  [Isolation] Cleanup error for task #{task_id} "
-                f"(branch '{branch_name}'): {e}"
-            )
-    # Clean up worktree base dir if empty (rmdir on non-empty dir raises
-    # OSError — that's expected when other worktrees exist, not an error).
-    try:
-        worktree_base.rmdir()
-    except OSError:
-        pass
-
+# --- Worktree isolation helpers removed in Phase 1 convergence (2026-05-23) ---
+# Functions _copy_hooks_to_worktree, _create_isolation_worktrees, _merge_task_branch,
+# _stash_uncommitted_in_worktree, and _cleanup_worktrees have been replaced by the
+# canonical implementation in equipa.worktree_manager. The parallel-dispatch flow
+# in run_parallel_tasks now uses create_worktree / merge_worktree_back / destroy_worktree
+# / mark_worktree_failed / mark_worktree_conflict from that module so single-task and
+# parallel dispatch share one implementation.
 
 async def run_parallel_tasks(task_ids: list[int], args) -> None:
     """Run multiple tasks concurrently with dev-test loops.
@@ -1408,16 +1101,24 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
             print("Aborted.")
             return
 
-    # Create per-task git worktrees for filesystem isolation
-    worktree_base = Path(project_dir) / ".forge-worktrees"
+    # Create per-task git worktrees for filesystem isolation.
+    # Phase 1 convergence (2026-05-23): the parallel path now uses
+    # worktree_manager.create() so single-task and parallel dispatch share
+    # one canonical implementation. Tasks that fail worktree creation fall
+    # back to sharing project_dir (logged as a warning).
     use_worktrees = len(tasks) > 1 and _is_git_repo(project_dir)
-    # Worktree creation issues 2-3 git commands per task. The helper is
-    # natively async (uses git_run_async) so the event loop is not
-    # blocked while subprocesses run.
-    worktree_dirs: dict[int, str] = (
-        await _create_isolation_worktrees(tasks, project_dir, worktree_base)
-        if use_worktrees else {}
-    )
+    worktree_dirs: dict[int, str] = {}
+    if use_worktrees:
+        for t in tasks:
+            try:
+                record = await create_worktree(t["id"], project_dir)
+                worktree_dirs[t["id"]] = record.path
+                print(f"  [Isolation] Task #{t['id']} -> {Path(record.path).name}")
+            except WorktreeError as e:
+                print(
+                    f"  [Isolation] WARNING: worktree creation failed for "
+                    f"task #{t['id']}, using shared dir: {e}"
+                )
 
     async def run_one_task(task):
         output = []
@@ -1574,36 +1275,35 @@ async def run_parallel_tasks(task_ids: list[int], args) -> None:
         print(f"Cost: ${total_cost:.4f}")
     print(f"{'#' * 60}")
 
-    # Sequential merge — merge task branches one at a time to avoid conflicts
-    merged_tasks_seq: set[int] = set()
+    # Sequential merge + cleanup — merge task branches one at a time via
+    # worktree_manager so single-task and parallel dispatch share one
+    # canonical implementation. On successful merge, destroy the worktree.
+    # On failed task (outcome not in success set) or merge failure, the
+    # worktree is retained on disk for operator inspection — Phase 3
+    # introduces --cleanup-worktrees for batch cleanup.
     if use_worktrees:
-        merge_candidates = []
         for r in results:
             if isinstance(r, Exception):
                 continue
-            if r.get("needs_merge", False) or (
-                r["task"]["id"] in worktree_dirs
-                and r["outcome"] in ("tests_passed", "no_tests")
-            ):
-                merge_candidates.append(r)
-
-        for r in merge_candidates:
             task_id = r["task"]["id"]
-            branch_name = f"forge-task-{task_id}"
-            # Each merge issues 6-12 git invocations; the helper is now
-            # natively async (uses git_run_async) so the event loop stays
-            # responsive for any background work draining post-gather.
-            merge_ok = await _merge_task_branch(
-                project_dir, task_id, branch_name,
-            )
-            if merge_ok:
-                r["merge_ok"] = True
-                merged_tasks_seq.add(task_id)
+            if task_id not in worktree_dirs:
+                continue
 
-    # Clean up worktrees — only delete branches that were successfully merged.
-    # Helper is natively async; per-task `git worktree remove` and
-    # `git branch -D` calls do not block the event loop.
-    if use_worktrees:
-        await _cleanup_worktrees(
-            project_dir, worktree_dirs, merged_tasks_seq, worktree_base,
-        )
+            if r["outcome"] in ("tests_passed", "no_tests"):
+                merge_result = await merge_worktree_back(task_id)
+                if merge_result.ok:
+                    r["merge_ok"] = True
+                    await destroy_worktree(task_id)
+                else:
+                    await mark_worktree_conflict(task_id, merge_result)
+                    print(
+                        f"  [Isolation] Task #{task_id} merge FAILED: "
+                        f"{merge_result.message}. Worktree retained at "
+                        f"{worktree_dirs[task_id]}"
+                    )
+            else:
+                await mark_worktree_failed(task_id)
+                print(
+                    f"  [Isolation] Task #{task_id} {r['outcome']}; "
+                    f"worktree retained at {worktree_dirs[task_id]}"
+                )

--- a/equipa/worktree_manager.py
+++ b/equipa/worktree_manager.py
@@ -1,20 +1,22 @@
 """EQUIPA worktree manager: git-worktree-isolated agent dispatch.
 
-Phase 1: primitives + single-task opt-in mode. Each isolated task gets:
+Each isolated task gets:
   - Its own git worktree at <project_dir>/forge_worktrees/<codename>-task-<id>/
   - A dedicated branch forge-task-<id>
   - On success-flagged exit: fast-forward merge back to the project's HEAD
     branch, worktree destroyed, branch deleted.
   - On failure or unexpected exception: worktree retained for inspection.
 
-Parallel concerns (real merge-lock semantics for concurrent writers,
---tasks A,B integration) are Phase 2 — see planning/worktree-isolation.md.
+Phase 1: primitives + single-task opt-in mode (--worktree).
+Phase 2: per-project merge lock for cross-process serialization.
+Phase 3: --cleanup-worktrees batch cleanup of failed/abandoned worktrees.
 
 Copyright 2026 Forgeborn
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 from contextlib import asynccontextmanager
@@ -22,6 +24,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, Optional
+
+from filelock import FileLock, Timeout as FileLockTimeout
 
 from equipa.db import db_conn
 from equipa.git_ops import git_run_async
@@ -35,6 +39,8 @@ STATUS_MERGED = "merged"
 STATUS_FAILED = "failed"
 STATUS_CONFLICT = "conflict"
 STATUS_ABANDONED = "abandoned"
+
+MERGE_LOCK_TIMEOUT_SECONDS = 300
 
 
 @dataclass
@@ -61,6 +67,12 @@ class WorktreeError(RuntimeError):
 
 
 # --- Helpers ---
+
+def _merge_lock_path(project_dir: str) -> Path:
+    """Per-project merge lock file. Lives in forge_worktrees/ (already gitignored)."""
+    lock_dir = Path(project_dir) / "forge_worktrees"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    return lock_dir / ".merge.lock"
 
 async def _stash_uncommitted(
     worktree_path: str,
@@ -336,7 +348,10 @@ async def destroy(task_id: int, keep_branch: bool = False) -> None:
 async def merge_back(task_id: int) -> MergeResult:
     """Merge the task's worktree branch back into the project's main branch.
 
-    Strategy (ported from dispatch.py._merge_task_branch with refinements):
+    Acquires a per-project file lock so concurrent merges (from parallel
+    dispatch or multiple CLI invocations) are serialized.
+
+    Strategy:
       1. Determine the project's current branch; fall back to main/master if
          the project is on a detached HEAD.
       2. Check the worktree branch is actually ahead of the project's HEAD.
@@ -347,10 +362,6 @@ async def merge_back(task_id: int) -> MergeResult:
          creates a merge commit when not. Returns ok if HEAD advances.
       5. If the merge fails (conflict), abort, try rebase-then-merge as a
          recovery path, fall back to ok=False with the branch preserved.
-
-    Phase 1 assumes single writer per project. Phase 2 will add a per-project
-    file lock around this function to serialize concurrent merges from
-    parallel dispatch.
     """
     with db_conn() as conn:
         row = conn.execute(
@@ -368,6 +379,38 @@ async def merge_back(task_id: int) -> MergeResult:
 
     project_dir = str(Path(worktree_path).parent.parent)
 
+    # Non-blocking acquire with async polling — acquire and release both run
+    # in the event loop thread (Windows msvcrt.locking requires same-thread
+    # lock/unlock on the same fd).
+    lock = FileLock(_merge_lock_path(project_dir), timeout=0)
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + MERGE_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            lock.acquire()
+            break
+        except FileLockTimeout:
+            if loop.time() >= deadline:
+                return MergeResult(
+                    ok=False,
+                    message=(
+                        f"Could not acquire merge lock for {project_dir} "
+                        f"within {MERGE_LOCK_TIMEOUT_SECONDS}s"
+                    ),
+                    branch=branch,
+                )
+            await asyncio.sleep(0.1)
+
+    try:
+        return await _merge_back_locked(task_id, project_dir, branch)
+    finally:
+        lock.release()
+
+
+async def _merge_back_locked(
+    task_id: int, project_dir: str, branch: str,
+) -> MergeResult:
+    """Inner merge logic, called with the per-project lock held."""
     # Step 1: resolve project's current branch, falling back to main/master.
     current = await git_run_async(["branch", "--show-current"], cwd=project_dir)
     main_branch = current.stdout.strip()
@@ -562,6 +605,106 @@ async def list_active(project_id: Optional[int] = None) -> list[WorktreeRecord]:
         )
         for r in rows
     ]
+
+
+# --- Cleanup (Phase 3) ---
+
+def list_stale(project_id: Optional[int] = None) -> list[WorktreeRecord]:
+    """List worktrees in terminal statuses (failed/conflict/abandoned)."""
+    sql = (
+        "SELECT id, task_id, project_id, path, branch, status, created_at, ended_at "
+        "FROM worktrees WHERE status IN (?, ?, ?)"
+    )
+    params: list = [STATUS_FAILED, STATUS_CONFLICT, STATUS_ABANDONED]
+    if project_id is not None:
+        sql += " AND project_id = ?"
+        params.append(project_id)
+    sql += " ORDER BY created_at ASC"
+
+    with db_conn() as conn:
+        rows = conn.execute(sql, params).fetchall()
+
+    return [
+        WorktreeRecord(
+            id=r["id"], task_id=r["task_id"], project_id=r["project_id"],
+            path=r["path"], branch=r["branch"], status=r["status"],
+            created_at=r["created_at"], ended_at=r["ended_at"],
+        )
+        for r in rows
+    ]
+
+
+async def cleanup_stale_worktree(record: WorktreeRecord) -> tuple[bool, str]:
+    """Clean up a single stale worktree: stash, remove directory, delete branch.
+
+    Returns (success, message).
+    """
+    project_dir = str(Path(record.path).parent.parent)
+
+    if Path(record.path).exists():
+        await _stash_uncommitted(record.path, record.task_id, record.branch)
+
+        r = await git_run_async(
+            ["worktree", "remove", "--force", record.path],
+            cwd=project_dir,
+        )
+        if r.returncode != 0:
+            try:
+                shutil.rmtree(record.path, ignore_errors=True)
+                await git_run_async(["worktree", "prune"], cwd=project_dir)
+            except Exception as e:
+                return False, f"Could not remove worktree directory: {e}"
+
+    r = await git_run_async(["branch", "-D", record.branch], cwd=project_dir)
+    if r.returncode != 0 and "not found" not in r.stderr.lower():
+        logger.warning(
+            "[worktree] cleanup: branch delete failed for %s: %s",
+            record.branch, r.stderr.strip(),
+        )
+
+    if record.status != STATUS_ABANDONED:
+        with db_conn(write=True) as conn:
+            conn.execute(
+                "UPDATE worktrees SET status = ?, ended_at = ? WHERE id = ?",
+                (STATUS_ABANDONED, _utcnow_iso(), record.id),
+            )
+
+    return True, (
+        f"Cleaned up task #{record.task_id} ({record.status}) "
+        f"at {Path(record.path).name}"
+    )
+
+
+async def cleanup_all_stale(
+    project_id: Optional[int] = None,
+    dry_run: bool = False,
+) -> list[tuple[WorktreeRecord, bool, str]]:
+    """Batch cleanup of all stale worktrees. Returns (record, success, message) tuples."""
+    stale = list_stale(project_id)
+    results: list[tuple[WorktreeRecord, bool, str]] = []
+
+    for record in stale:
+        disk_exists = Path(record.path).exists()
+        if dry_run:
+            status_label = "EXISTS" if disk_exists else "MISSING"
+            results.append((
+                record, True,
+                f"[DRY RUN] Would clean up task #{record.task_id} "
+                f"({record.status}, disk={status_label}) branch={record.branch}",
+            ))
+        elif not disk_exists:
+            if record.status != STATUS_ABANDONED:
+                with db_conn(write=True) as conn:
+                    conn.execute(
+                        "UPDATE worktrees SET status = ?, ended_at = ? WHERE id = ?",
+                        (STATUS_ABANDONED, _utcnow_iso(), record.id),
+                    )
+            results.append((record, True, "Already removed from disk; DB updated"))
+        else:
+            success, msg = await cleanup_stale_worktree(record)
+            results.append((record, success, msg))
+
+    return results
 
 
 # --- Context manager ---

--- a/equipa/worktree_manager.py
+++ b/equipa/worktree_manager.py
@@ -1,0 +1,648 @@
+"""EQUIPA worktree manager: git-worktree-isolated agent dispatch.
+
+Phase 1: primitives + single-task opt-in mode. Each isolated task gets:
+  - Its own git worktree at <project_dir>/forge_worktrees/<codename>-task-<id>/
+  - A dedicated branch forge-task-<id>
+  - On success-flagged exit: fast-forward merge back to the project's HEAD
+    branch, worktree destroyed, branch deleted.
+  - On failure or unexpected exception: worktree retained for inspection.
+
+Parallel concerns (real merge-lock semantics for concurrent writers,
+--tasks A,B integration) are Phase 2 — see planning/worktree-isolation.md.
+
+Copyright 2026 Forgeborn
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import AsyncIterator, Optional
+
+from equipa.db import db_conn
+from equipa.git_ops import git_run_async
+
+logger = logging.getLogger(__name__)
+
+
+# --- Status constants ---
+STATUS_ACTIVE = "active"
+STATUS_MERGED = "merged"
+STATUS_FAILED = "failed"
+STATUS_CONFLICT = "conflict"
+STATUS_ABANDONED = "abandoned"
+
+
+@dataclass
+class WorktreeRecord:
+    id: int
+    task_id: int
+    project_id: int
+    path: str
+    branch: str
+    status: str
+    created_at: str
+    ended_at: Optional[str] = None
+
+
+@dataclass
+class MergeResult:
+    ok: bool
+    message: str = ""
+    branch: str = ""
+
+
+class WorktreeError(RuntimeError):
+    """Raised when worktree operations fail in ways the caller must surface."""
+
+
+# --- Helpers ---
+
+async def _stash_uncommitted(
+    worktree_path: str,
+    task_id: int,
+    branch: str,
+) -> bool:
+    """Stash uncommitted changes in a worktree before it is destroyed.
+
+    Returns True if a stash was created, False otherwise.
+    Stash message is tagged so it can be located later:
+    ``equipa-early-term task-<id> branch-<branch>``.
+
+    Silent on failure — cleanup must continue even if the stash cannot be saved.
+    """
+    if not Path(worktree_path).exists():
+        return False
+    try:
+        status = await git_run_async(
+            ["status", "--porcelain"], cwd=worktree_path,
+        )
+        if status.returncode != 0 or not status.stdout.strip():
+            return False
+        stash_msg = f"equipa-early-term task-{task_id} branch-{branch}"
+        result = await git_run_async(
+            ["stash", "push", "-u", "-m", stash_msg], cwd=worktree_path,
+        )
+        if result.returncode == 0 and "No local changes" not in result.stdout:
+            logger.info(
+                "[worktree] Task #%s: stashed uncommitted work on '%s'",
+                task_id, branch,
+            )
+            return True
+    except Exception as e:
+        logger.warning(
+            "[worktree] Could not stash uncommitted work for task #%s: %s",
+            task_id, e,
+        )
+    return False
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _resolve_project(project_dir: str) -> tuple[int, str]:
+    """Look up project_id and codename from project_dir.
+
+    Returns (project_id, codename). Raises WorktreeError if no match.
+    Does a normalized-path comparison so Windows path variants resolve.
+    """
+    target = Path(project_dir).resolve()
+    with db_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, codename, local_path FROM projects "
+            "WHERE local_path IS NOT NULL"
+        ).fetchall()
+        for r in rows:
+            try:
+                if Path(r["local_path"]).resolve() == target:
+                    return r["id"], (r["codename"] or "project")
+            except (OSError, ValueError):
+                continue
+    raise WorktreeError(
+        f"No project in TheForge has local_path matching {target}. "
+        "Cannot create worktree without a project mapping."
+    )
+
+
+def _ensure_gitignored(project_dir: str) -> None:
+    """Ensure forge_worktrees/ is listed in the project's .gitignore.
+
+    Append-only and idempotent. Does not commit the change — operator can
+    commit it whenever convenient. The agent will see this as an uncommitted
+    diff, which is intentional and harmless.
+    """
+    gitignore = Path(project_dir) / ".gitignore"
+    line = "forge_worktrees/"
+    if not gitignore.exists():
+        gitignore.write_text(line + "\n", encoding="utf-8")
+        return
+    contents = gitignore.read_text(encoding="utf-8")
+    for entry in contents.splitlines():
+        stripped = entry.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.rstrip("/").lstrip("/") == "forge_worktrees":
+            return
+    if not contents.endswith("\n"):
+        contents += "\n"
+    contents += line + "\n"
+    gitignore.write_text(contents, encoding="utf-8")
+
+
+def _copy_hooks_and_markers(project_dir: str, worktree_path: str) -> None:
+    """Copy git hooks and plugin boundary markers into a fresh worktree.
+
+    Worktrees do NOT inherit .git/hooks from the parent repo — they share
+    the parent's .git database but have their own per-worktree hooks dir
+    that is empty by default. Pre-commit hooks (plugin boundary checks,
+    linters, etc.) won't fire in worktrees unless we explicitly copy them.
+
+    Ported from dispatch.py._copy_hooks_to_worktree (Phase 1 convergence,
+    2026-05-23). Also copies .plugin-boundary-markers if present at the
+    project root, since the pre-commit hook consumes it.
+    """
+    main_hooks = Path(project_dir) / ".git" / "hooks"
+    wt_git = Path(worktree_path) / ".git"
+
+    if main_hooks.is_dir() and wt_git.is_file():
+        gitdir_line = wt_git.read_text(encoding="utf-8").strip()
+        gitdir = gitdir_line.removeprefix("gitdir: ").strip()
+        wt_hooks = Path(gitdir) / "hooks"
+        wt_hooks.mkdir(parents=True, exist_ok=True)
+        for hook in main_hooks.iterdir():
+            if hook.is_file() and not hook.name.endswith(".sample"):
+                dest = wt_hooks / hook.name
+                try:
+                    shutil.copy2(str(hook), str(dest))
+                except OSError as e:
+                    logger.warning(
+                        "[worktree] failed to copy hook %s -> %s: %s",
+                        hook, dest, e,
+                    )
+
+    markers_src = Path(project_dir) / ".plugin-boundary-markers"
+    markers_dst = Path(worktree_path) / ".plugin-boundary-markers"
+    if markers_src.exists() and not markers_dst.exists():
+        try:
+            shutil.copy2(str(markers_src), str(markers_dst))
+        except OSError as e:
+            logger.warning(
+                "[worktree] failed to copy plugin-boundary-markers: %s", e,
+            )
+
+
+# --- Core API ---
+
+async def create(task_id: int, project_dir: str) -> WorktreeRecord:
+    """Create a git worktree for the given task.
+
+    Raises WorktreeError if the worktree directory or branch already exists,
+    or if git worktree add fails.
+    """
+    project_id, codename = _resolve_project(project_dir)
+
+    project_root = Path(project_dir)
+    worktrees_root = project_root / "forge_worktrees"
+    worktree_path = worktrees_root / f"{codename}-task-{task_id}"
+    branch = f"forge-task-{task_id}"
+
+    if worktree_path.exists():
+        raise WorktreeError(
+            f"Worktree path already exists: {worktree_path}. "
+            f"A prior dispatch on task #{task_id} likely failed and the worktree was retained. "
+            f"Inspect, then remove manually or via --cleanup-worktrees (Phase 3)."
+        )
+
+    _ensure_gitignored(project_dir)
+    worktrees_root.mkdir(parents=True, exist_ok=True)
+
+    # Try to create the worktree on a fresh branch from current HEAD. If the
+    # branch already exists (orphaned from a prior failed run that didn't
+    # clean up), force-delete it and retry once. The path-exists case is
+    # handled above; this is purely a branch-leftover recovery, ported from
+    # dispatch.py._create_isolation_worktrees.
+    r = await git_run_async(
+        ["worktree", "add", str(worktree_path), "-b", branch, "HEAD"],
+        cwd=project_dir,
+    )
+    if r.returncode != 0:
+        del_r = await git_run_async(
+            ["branch", "-D", branch], cwd=project_dir,
+        )
+        if del_r.returncode != 0 and "not found" not in del_r.stderr.lower():
+            raise WorktreeError(
+                f"git worktree add failed and orphan-branch cleanup also failed:\n"
+                f"  worktree add: {r.stderr.strip() or r.stdout.strip()}\n"
+                f"  branch -D {branch}: {del_r.stderr.strip()}"
+            )
+        r = await git_run_async(
+            ["worktree", "add", str(worktree_path), "-b", branch, "HEAD"],
+            cwd=project_dir,
+        )
+        if r.returncode != 0:
+            raise WorktreeError(
+                f"git worktree add failed after orphan-branch cleanup: "
+                f"{r.stderr.strip() or r.stdout.strip()}"
+            )
+
+    _copy_hooks_and_markers(project_dir, str(worktree_path))
+
+    with db_conn(write=True) as conn:
+        cursor = conn.execute(
+            """INSERT INTO worktrees (task_id, project_id, path, branch, status)
+               VALUES (?, ?, ?, ?, ?)""",
+            (task_id, project_id, str(worktree_path), branch, STATUS_ACTIVE),
+        )
+        wt_id = cursor.lastrowid
+        row = conn.execute(
+            "SELECT id, task_id, project_id, path, branch, status, created_at, ended_at "
+            "FROM worktrees WHERE id = ?",
+            (wt_id,),
+        ).fetchone()
+
+    logger.info(
+        "[worktree] Created task=%s at %s on branch %s",
+        task_id, worktree_path, branch,
+    )
+    return WorktreeRecord(
+        id=row["id"],
+        task_id=row["task_id"],
+        project_id=row["project_id"],
+        path=row["path"],
+        branch=row["branch"],
+        status=row["status"],
+        created_at=row["created_at"],
+        ended_at=row["ended_at"],
+    )
+
+
+async def destroy(task_id: int, keep_branch: bool = False) -> None:
+    """Remove the worktree (and optionally the branch) for the given task.
+
+    Looks up the most recent worktree for the task. Safe to call regardless
+    of current status; updates DB row to 'abandoned' on completion.
+    Logs but does not raise if git commands fail (best-effort cleanup).
+    """
+    with db_conn() as conn:
+        row = conn.execute(
+            "SELECT id, path, branch FROM worktrees "
+            "WHERE task_id = ? AND status IN (?, ?, ?, ?) "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id, STATUS_ACTIVE, STATUS_MERGED, STATUS_FAILED, STATUS_CONFLICT),
+        ).fetchone()
+        if row is None:
+            logger.warning("[worktree] destroy: no record for task=%s", task_id)
+            return
+        worktree_path = row["path"]
+        branch = row["branch"]
+
+    project_dir = str(Path(worktree_path).parent.parent)
+
+    await _stash_uncommitted(worktree_path, task_id, branch)
+
+    r = await git_run_async(
+        ["worktree", "remove", "--force", worktree_path],
+        cwd=project_dir,
+    )
+    if r.returncode != 0:
+        logger.warning(
+            "[worktree] git worktree remove failed for %s: %s",
+            worktree_path, r.stderr.strip(),
+        )
+
+    if not keep_branch:
+        r = await git_run_async(["branch", "-D", branch], cwd=project_dir)
+        if r.returncode != 0:
+            logger.warning(
+                "[worktree] branch delete failed for %s: %s",
+                branch, r.stderr.strip(),
+            )
+
+    with db_conn(write=True) as conn:
+        conn.execute(
+            "UPDATE worktrees SET status = ?, ended_at = ? "
+            "WHERE task_id = ? AND status IN (?, ?, ?)",
+            (STATUS_ABANDONED, _utcnow_iso(),
+             task_id, STATUS_ACTIVE, STATUS_FAILED, STATUS_CONFLICT),
+        )
+
+    logger.info("[worktree] Destroyed task=%s", task_id)
+
+
+async def merge_back(task_id: int) -> MergeResult:
+    """Merge the task's worktree branch back into the project's main branch.
+
+    Strategy (ported from dispatch.py._merge_task_branch with refinements):
+      1. Determine the project's current branch; fall back to main/master if
+         the project is on a detached HEAD.
+      2. Check the worktree branch is actually ahead of the project's HEAD.
+         If no commits ahead, skip the merge entirely and report it.
+      3. Stash any uncommitted changes in the project dir (preserved across
+         the merge, restored in the finally block).
+      4. ``git merge --no-edit <branch>`` — fast-forwards when possible,
+         creates a merge commit when not. Returns ok if HEAD advances.
+      5. If the merge fails (conflict), abort, try rebase-then-merge as a
+         recovery path, fall back to ok=False with the branch preserved.
+
+    Phase 1 assumes single writer per project. Phase 2 will add a per-project
+    file lock around this function to serialize concurrent merges from
+    parallel dispatch.
+    """
+    with db_conn() as conn:
+        row = conn.execute(
+            "SELECT path, branch FROM worktrees WHERE task_id = ? AND status = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id, STATUS_ACTIVE),
+        ).fetchone()
+        if row is None:
+            return MergeResult(
+                ok=False,
+                message=f"No active worktree for task={task_id}",
+            )
+        worktree_path = row["path"]
+        branch = row["branch"]
+
+    project_dir = str(Path(worktree_path).parent.parent)
+
+    # Step 1: resolve project's current branch, falling back to main/master.
+    current = await git_run_async(["branch", "--show-current"], cwd=project_dir)
+    main_branch = current.stdout.strip()
+    if not main_branch:
+        for candidate in ("main", "master"):
+            check = await git_run_async(
+                ["show-ref", "--verify", f"refs/heads/{candidate}"],
+                cwd=project_dir,
+            )
+            if check.returncode == 0:
+                co = await git_run_async(
+                    ["checkout", candidate], cwd=project_dir,
+                )
+                if co.returncode == 0:
+                    main_branch = candidate
+                    break
+        if not main_branch:
+            return MergeResult(
+                ok=False,
+                message="project HEAD is detached and no main/master ref exists",
+                branch=branch,
+            )
+
+    # Step 2: verify there are commits to merge.
+    ahead = await git_run_async(
+        ["log", "--oneline", f"HEAD..{branch}"], cwd=project_dir,
+    )
+    if ahead.returncode != 0:
+        return MergeResult(
+            ok=False,
+            message=f"could not check commits ahead: {ahead.stderr.strip()}",
+            branch=branch,
+        )
+    if not ahead.stdout.strip():
+        # Not a failure — the agent simply did not commit anything.
+        with db_conn(write=True) as conn:
+            conn.execute(
+                "UPDATE worktrees SET status = ?, ended_at = ? "
+                "WHERE task_id = ? AND status = ?",
+                (STATUS_MERGED, _utcnow_iso(), task_id, STATUS_ACTIVE),
+            )
+        logger.info(
+            "[worktree] Merged task=%s: branch %s had no commits ahead of %s",
+            task_id, branch, main_branch,
+        )
+        return MergeResult(
+            ok=True,
+            message=f"no commits ahead — nothing to merge",
+            branch=branch,
+        )
+
+    # Step 3: stash any uncommitted work in the project dir.
+    stash_result = await git_run_async(["stash"], cwd=project_dir)
+    had_stash = "Saved working directory" in (stash_result.stdout or "")
+
+    pre_head_r = await git_run_async(["rev-parse", "HEAD"], cwd=project_dir)
+    pre_head = pre_head_r.stdout.strip() if pre_head_r.returncode == 0 else ""
+
+    try:
+        # Step 4: attempt the merge.
+        merge_r = await git_run_async(
+            ["merge", "--no-edit", branch], cwd=project_dir,
+        )
+        post_head_r = await git_run_async(["rev-parse", "HEAD"], cwd=project_dir)
+        post_head = post_head_r.stdout.strip() if post_head_r.returncode == 0 else ""
+
+        if merge_r.returncode == 0 and post_head and post_head != pre_head:
+            with db_conn(write=True) as conn:
+                conn.execute(
+                    "UPDATE worktrees SET status = ?, ended_at = ? "
+                    "WHERE task_id = ? AND status = ?",
+                    (STATUS_MERGED, _utcnow_iso(), task_id, STATUS_ACTIVE),
+                )
+            logger.info(
+                "[worktree] Merged task=%s branch=%s into %s (%s -> %s)",
+                task_id, branch, main_branch, pre_head[:8], post_head[:8],
+            )
+            return MergeResult(ok=True, message="merged", branch=branch)
+
+        if merge_r.returncode == 0:
+            # Merge reported success but HEAD didn't move — anomalous.
+            return MergeResult(
+                ok=False,
+                message=f"merge returned 0 but HEAD unchanged at {pre_head[:8]}",
+                branch=branch,
+            )
+
+        # Step 5: conflict recovery — abort, rebase, retry merge.
+        await git_run_async(["merge", "--abort"], cwd=project_dir)
+        rebase_r = await git_run_async(
+            ["rebase", "HEAD", branch], cwd=project_dir,
+        )
+        if rebase_r.returncode != 0:
+            await git_run_async(["rebase", "--abort"], cwd=project_dir)
+            return MergeResult(
+                ok=False,
+                message=(
+                    f"merge conflict and rebase recovery failed; "
+                    f"branch {branch} preserved. "
+                    f"merge stderr: {(merge_r.stderr or '').strip()[:200]}"
+                ),
+                branch=branch,
+            )
+
+        merge2_r = await git_run_async(
+            ["merge", "--no-edit", branch], cwd=project_dir,
+        )
+        post2_r = await git_run_async(["rev-parse", "HEAD"], cwd=project_dir)
+        post2_head = post2_r.stdout.strip() if post2_r.returncode == 0 else ""
+
+        if merge2_r.returncode == 0 and post2_head and post2_head != pre_head:
+            with db_conn(write=True) as conn:
+                conn.execute(
+                    "UPDATE worktrees SET status = ?, ended_at = ? "
+                    "WHERE task_id = ? AND status = ?",
+                    (STATUS_MERGED, _utcnow_iso(), task_id, STATUS_ACTIVE),
+                )
+            logger.info(
+                "[worktree] Merged task=%s branch=%s (after rebase recovery)",
+                task_id, branch,
+            )
+            return MergeResult(
+                ok=True,
+                message="merged after rebase recovery",
+                branch=branch,
+            )
+
+        await git_run_async(["merge", "--abort"], cwd=project_dir)
+        return MergeResult(
+            ok=False,
+            message=(
+                f"merge failed even after rebase; branch {branch} preserved"
+            ),
+            branch=branch,
+        )
+    finally:
+        if had_stash:
+            pop_r = await git_run_async(["stash", "pop"], cwd=project_dir)
+            if pop_r.returncode != 0:
+                logger.warning(
+                    "[worktree] stash pop failed after merge of task=%s: %s",
+                    task_id, pop_r.stderr.strip(),
+                )
+
+
+async def mark_failed(task_id: int) -> None:
+    """Mark the active worktree for task_id as failed. Worktree retained."""
+    with db_conn(write=True) as conn:
+        conn.execute(
+            "UPDATE worktrees SET status = ?, ended_at = ? "
+            "WHERE task_id = ? AND status = ?",
+            (STATUS_FAILED, _utcnow_iso(), task_id, STATUS_ACTIVE),
+        )
+    logger.info(
+        "[worktree] Marked task=%s as failed (worktree retained)", task_id,
+    )
+
+
+async def mark_conflict(task_id: int, result: MergeResult) -> None:
+    """Mark the active worktree for task_id as conflict."""
+    with db_conn(write=True) as conn:
+        conn.execute(
+            "UPDATE worktrees SET status = ?, ended_at = ? "
+            "WHERE task_id = ? AND status = ?",
+            (STATUS_CONFLICT, _utcnow_iso(), task_id, STATUS_ACTIVE),
+        )
+    logger.warning(
+        "[worktree] Conflict on task=%s: %s", task_id, result.message,
+    )
+
+
+async def list_active(project_id: Optional[int] = None) -> list[WorktreeRecord]:
+    """List worktrees in 'active' status. Filter by project_id if given."""
+    sql = (
+        "SELECT id, task_id, project_id, path, branch, status, created_at, ended_at "
+        "FROM worktrees WHERE status = ?"
+    )
+    params: list = [STATUS_ACTIVE]
+    if project_id is not None:
+        sql += " AND project_id = ?"
+        params.append(project_id)
+    sql += " ORDER BY created_at DESC"
+
+    with db_conn() as conn:
+        rows = conn.execute(sql, params).fetchall()
+
+    return [
+        WorktreeRecord(
+            id=r["id"], task_id=r["task_id"], project_id=r["project_id"],
+            path=r["path"], branch=r["branch"], status=r["status"],
+            created_at=r["created_at"], ended_at=r["ended_at"],
+        )
+        for r in rows
+    ]
+
+
+# --- Context manager ---
+
+class TaskWorkspace:
+    """Async context manager that yields an effective working directory.
+
+    isolate=False: yields self with path=project_dir. set_success is a no-op.
+    isolate=True : creates a git worktree on enter, yields self with path set
+                   to the worktree path. On exit:
+                     - If an exception escaped the block: mark_failed, re-raise.
+                     - If set_success(True) was called: merge_back, then destroy.
+                     - Otherwise: mark_failed (worktree retained on disk).
+
+    Example:
+        async with TaskWorkspace(task_id, project_dir, isolate=True) as ws:
+            outcome = await dispatch(ws.path, ...)
+            ws.set_success(outcome in success_outcomes)
+
+    Falls back to non-isolated mode (with a warning) if project_dir is not a
+    git repo, so callers can pass isolate=True unconditionally.
+    """
+
+    def __init__(self, task_id: int, project_dir: str, isolate: bool):
+        self.task_id = task_id
+        self.project_dir = project_dir
+        self.isolate = isolate
+        self.path: str = project_dir
+        self._success = False
+        self._record: Optional[WorktreeRecord] = None
+
+    async def __aenter__(self) -> "TaskWorkspace":
+        if not self.isolate:
+            return self
+
+        if not (Path(self.project_dir) / ".git").exists():
+            logger.warning(
+                "[worktree] %s is not a git repo; falling back to non-isolated mode",
+                self.project_dir,
+            )
+            self.isolate = False
+            return self
+
+        self._record = await create(self.task_id, self.project_dir)
+        self.path = self._record.path
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if not self.isolate:
+            return False
+
+        if exc_type is not None:
+            try:
+                await mark_failed(self.task_id)
+            except Exception:
+                logger.exception(
+                    "[worktree] mark_failed during exception unwind also failed",
+                )
+            return False
+
+        if self._success:
+            result = await merge_back(self.task_id)
+            if result.ok:
+                await destroy(self.task_id)
+            else:
+                await mark_conflict(self.task_id, result)
+        else:
+            await mark_failed(self.task_id)
+        return False
+
+    def set_success(self, ok: bool = True) -> None:
+        self._success = ok
+
+
+@asynccontextmanager
+async def task_workspace(
+    task_id: int,
+    project_dir: str,
+    isolate: bool,
+) -> AsyncIterator[TaskWorkspace]:
+    """Functional alias for TaskWorkspace, for callers preferring an asynccontextmanager."""
+    ws = TaskWorkspace(task_id, project_dir, isolate)
+    async with ws:
+        yield ws

--- a/schema.sql
+++ b/schema.sql
@@ -290,6 +290,7 @@ CREATE TABLE agent_runs (
     error_summary TEXT,
     turns_allocated INTEGER,
     prompt_version TEXT DEFAULT 'baseline',
+    worktree_path TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (task_id) REFERENCES tasks(id),
     FOREIGN KEY (project_id) REFERENCES projects(id)
@@ -753,8 +754,27 @@ CREATE INDEX IF NOT EXISTS idx_agent_sessions_expires
     ON agent_sessions(expires_at);
 
 -- ============================================================
+-- v12: Worktree isolation tracking
+-- ============================================================
+CREATE TABLE IF NOT EXISTS worktrees (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id INTEGER NOT NULL,
+    project_id INTEGER NOT NULL,
+    path TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    status TEXT NOT NULL,  -- active / merged / failed / conflict / abandoned
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    ended_at DATETIME,
+    FOREIGN KEY (task_id) REFERENCES tasks(id),
+    FOREIGN KEY (project_id) REFERENCES projects(id)
+);
+CREATE INDEX IF NOT EXISTS idx_worktrees_status ON worktrees(status);
+CREATE INDEX IF NOT EXISTS idx_worktrees_task ON worktrees(task_id);
+CREATE INDEX IF NOT EXISTS idx_worktrees_project ON worktrees(project_id);
+
+-- ============================================================
 -- VERSION STAMP
 -- ============================================================
--- Marks fresh installs as v11. Migrations handle upgrades from older versions.
-PRAGMA user_version = 11;
+-- Marks fresh installs as v12. Migrations handle upgrades from older versions.
+PRAGMA user_version = 12;
 

--- a/tests/test_dispatch_isolation_helpers.py
+++ b/tests/test_dispatch_isolation_helpers.py
@@ -34,11 +34,16 @@ from equipa.worktree_manager import (
     STATUS_CONFLICT,
     STATUS_FAILED,
     STATUS_MERGED,
+    MERGE_LOCK_TIMEOUT_SECONDS,
     TaskWorkspace,
     WorktreeError,
+    _merge_lock_path,
+    cleanup_all_stale,
+    cleanup_stale_worktree,
     create,
     destroy,
     list_active,
+    list_stale,
     mark_conflict,
     mark_failed,
     merge_back,
@@ -396,3 +401,220 @@ def test_task_workspace_non_git_dir_falls_back(tmp_path, isolated_env):
             assert ws.isolate is False
 
     _run(_run_ws())
+
+
+# --- Phase 2: merge lock ---
+
+
+def test_merge_back_creates_lock_file(isolated_env):
+    """merge_back should create a .merge.lock in forge_worktrees/."""
+    repo, _, _ = isolated_env
+    record = _run(create(70, str(repo)))
+    wt = Path(record.path)
+    (wt / "locktest.txt").write_text("lock test\n")
+    _git(wt, "add", "locktest.txt")
+    _git(wt, "commit", "-m", "lock test commit")
+
+    _run(merge_back(70))
+
+    lock_path = _merge_lock_path(str(repo))
+    assert lock_path.exists()
+
+
+def test_merge_back_serializes_concurrent_merges(isolated_env):
+    """Two concurrent merge_back calls on the same project should both
+    succeed — the lock serializes them so they don't interleave."""
+    repo, _, _ = isolated_env
+    _run(create(100, str(repo)))
+    _run(create(101, str(repo)))
+
+    wt100 = Path(_run(list_active())[1].path)  # older = index 1
+    wt101 = Path(_run(list_active())[0].path)  # newer = index 0
+
+    (wt100 / "file_a.txt").write_text("from task 100\n")
+    _git(wt100, "add", "file_a.txt")
+    _git(wt100, "commit", "-m", "task 100 commit")
+
+    (wt101 / "file_b.txt").write_text("from task 101\n")
+    _git(wt101, "add", "file_b.txt")
+    _git(wt101, "commit", "-m", "task 101 commit")
+
+    async def _merge_both():
+        r1, r2 = await asyncio.gather(merge_back(100), merge_back(101))
+        return r1, r2
+
+    r1, r2 = _run(_merge_both())
+
+    assert r1.ok, f"merge task 100 failed: {r1.message}"
+    assert r2.ok, f"merge task 101 failed: {r2.message}"
+    assert (repo / "file_a.txt").exists()
+    assert (repo / "file_b.txt").exists()
+
+
+def test_merge_lock_timeout(isolated_env, monkeypatch):
+    """If the lock can't be acquired within the timeout, merge_back should
+    return ok=False with a meaningful message."""
+    import equipa.worktree_manager as wm
+
+    repo, _, _ = isolated_env
+    record = _run(create(80, str(repo)))
+    wt = Path(record.path)
+    (wt / "timeout.txt").write_text("timeout test\n")
+    _git(wt, "add", "timeout.txt")
+    _git(wt, "commit", "-m", "timeout commit")
+
+    monkeypatch.setattr(wm, "MERGE_LOCK_TIMEOUT_SECONDS", 0.2)
+
+    lock_path = _merge_lock_path(str(repo))
+    from filelock import FileLock
+    blocker = FileLock(lock_path)
+    blocker.acquire()
+    try:
+        result = _run(merge_back(80))
+        assert result.ok is False
+        assert "lock" in result.message.lower()
+    finally:
+        blocker.release()
+
+
+def test_merge_lock_path_creates_directory(tmp_path):
+    """_merge_lock_path should create forge_worktrees/ if missing."""
+    fake_project = tmp_path / "project"
+    fake_project.mkdir()
+
+    lock_path = _merge_lock_path(str(fake_project))
+
+    assert lock_path.parent.exists()
+    assert lock_path.name == ".merge.lock"
+
+
+# --- Phase 3: cleanup ---
+
+
+def test_list_stale_returns_failed_and_conflict(isolated_env):
+    repo, _, project_id = isolated_env
+    _run(create(200, str(repo)))
+    _run(create(201, str(repo)))
+    _run(create(202, str(repo)))
+
+    _run(mark_failed(200))
+    _run(mark_conflict(201, MergeResult(ok=False, message="conflict")))
+    # 202 stays active
+
+    stale = list_stale(project_id)
+    stale_ids = {r.task_id for r in stale}
+    assert 200 in stale_ids
+    assert 201 in stale_ids
+    assert 202 not in stale_ids
+
+
+def test_list_stale_filters_by_project(isolated_env):
+    repo, db_path, project_id = isolated_env
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO projects (name, codename, local_path) VALUES (?, ?, ?)",
+        ("Other", "other", str(repo.parent / "other")),
+    )
+    other_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        "INSERT INTO worktrees (task_id, project_id, path, branch, status) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (999, other_id, str(repo.parent / "other" / "forge_worktrees" / "other-task-999"),
+         "forge-task-999", STATUS_FAILED),
+    )
+    conn.commit()
+    conn.close()
+
+    _run(create(210, str(repo)))
+    _run(mark_failed(210))
+
+    all_stale = list_stale()
+    assert any(r.task_id == 999 for r in all_stale)
+    assert any(r.task_id == 210 for r in all_stale)
+
+    filtered = list_stale(project_id)
+    assert not any(r.task_id == 999 for r in filtered)
+    assert any(r.task_id == 210 for r in filtered)
+
+
+def test_cleanup_stale_worktree_removes_and_updates_db(isolated_env):
+    repo, db_path, _ = isolated_env
+    record = _run(create(220, str(repo)))
+    _run(mark_failed(220))
+
+    stale = list_stale()
+    target = [r for r in stale if r.task_id == 220][0]
+
+    success, msg = _run(cleanup_stale_worktree(target))
+
+    assert success
+    assert not Path(record.path).exists()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status FROM worktrees WHERE task_id = ?", (220,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_ABANDONED
+
+
+def test_cleanup_stale_worktree_stashes_uncommitted(isolated_env):
+    repo, _, _ = isolated_env
+    record = _run(create(230, str(repo)))
+    wt = Path(record.path)
+
+    (wt / "wip.py").write_text("print('work in progress')\n")
+    _git(wt, "add", "wip.py")
+
+    _run(mark_failed(230))
+
+    stale = list_stale()
+    target = [r for r in stale if r.task_id == 230][0]
+    _run(cleanup_stale_worktree(target))
+
+    stash_list = _git(repo, "stash", "list").stdout
+    assert "equipa-early-term task-230" in stash_list
+
+
+def test_cleanup_all_stale_dry_run(isolated_env):
+    repo, db_path, _ = isolated_env
+    record = _run(create(240, str(repo)))
+    _run(mark_failed(240))
+
+    results = _run(cleanup_all_stale(dry_run=True))
+
+    assert len(results) >= 1
+    assert all("DRY RUN" in msg for _, _, msg in results)
+    assert Path(record.path).exists()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status FROM worktrees WHERE task_id = ?", (240,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_FAILED
+
+
+def test_cleanup_all_stale_handles_missing_directory(isolated_env):
+    repo, db_path, _ = isolated_env
+    record = _run(create(250, str(repo)))
+    _run(mark_failed(250))
+
+    shutil.rmtree(record.path)
+
+    results = _run(cleanup_all_stale())
+    target_results = [(r, ok, msg) for r, ok, msg in results if r.task_id == 250]
+    assert len(target_results) == 1
+    assert target_results[0][1] is True
+    assert "disk" in target_results[0][2].lower() or "Already" in target_results[0][2]
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status FROM worktrees WHERE task_id = ?", (250,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_ABANDONED

--- a/tests/test_dispatch_isolation_helpers.py
+++ b/tests/test_dispatch_isolation_helpers.py
@@ -1,16 +1,17 @@
-"""Unit tests for the worktree-isolation helpers extracted from
-run_parallel_tasks: _create_isolation_worktrees, _merge_task_branch,
-and _cleanup_worktrees.
+"""Unit tests for equipa.worktree_manager — the canonical worktree-isolation
+implementation that replaced the inline helpers in dispatch.py (Phase 1
+convergence, 2026-05-23).
 
-These helpers exist because run_parallel_tasks was a 295-line function
-in which silent ``except Exception: pass`` made worktree-merge data-loss
-(open question #332) impossible to diagnose. The tests here exercise:
-
-1. happy path — helper does its job, prints expected breadcrumbs
-2. error path — helper logs the error explicitly and does NOT swallow it
+Tests exercise:
+  1. create  — worktree + branch + DB row created
+  2. merge_back — commits land on main, no-commits case handled
+  3. destroy — stash-before-remove, branch cleanup
+  4. mark_failed / mark_conflict — DB status transitions
+  5. TaskWorkspace context manager — success and failure paths
 
 Tests use real ``git`` subprocess calls inside ``tmp_path`` repos so the
-helper logic is exercised end-to-end without mocking subprocess.
+worktree logic is exercised end-to-end. A temporary SQLite DB (from
+schema.sql) replaces the production TheForge DB via monkeypatch.
 
 Copyright 2026 Forgeborn
 """
@@ -19,34 +20,32 @@ from __future__ import annotations
 
 import asyncio
 import shutil
+import sqlite3
 import subprocess
 from pathlib import Path
 
 import pytest
 
-from equipa.dispatch import (
-    _cleanup_worktrees as _cleanup_worktrees_async,
-    _create_isolation_worktrees as _create_isolation_worktrees_async,
-    _merge_task_branch as _merge_task_branch_async,
+import equipa.constants as constants
+import equipa.db as db_mod
+from equipa.worktree_manager import (
+    STATUS_ACTIVE,
+    STATUS_ABANDONED,
+    STATUS_CONFLICT,
+    STATUS_FAILED,
+    STATUS_MERGED,
+    TaskWorkspace,
+    WorktreeError,
+    create,
+    destroy,
+    list_active,
+    mark_conflict,
+    mark_failed,
+    merge_back,
+    MergeResult,
 )
 
-
-def _create_isolation_worktrees(tasks, project_dir, base):
-    return asyncio.run(
-        _create_isolation_worktrees_async(tasks, project_dir, base),
-    )
-
-
-def _merge_task_branch(project_dir, task_id, branch_name):
-    return asyncio.run(
-        _merge_task_branch_async(project_dir, task_id, branch_name),
-    )
-
-
-def _cleanup_worktrees(project_dir, worktree_dirs, merged_tasks, base):
-    return asyncio.run(
-        _cleanup_worktrees_async(project_dir, worktree_dirs, merged_tasks, base),
-    )
+REPO_ROOT_REAL = Path(__file__).resolve().parent.parent
 
 
 def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
@@ -72,203 +71,328 @@ def _git_available() -> bool:
 pytestmark = pytest.mark.skipif(not _git_available(), reason="git not available")
 
 
-# --- _create_isolation_worktrees ---
+@pytest.fixture
+def isolated_env(tmp_path, monkeypatch):
+    """Create a temp git repo + temp DB with a project row pointing at it.
 
-
-def test_create_isolation_worktrees_happy_path(tmp_path, capsys):
+    Returns ``(repo_path, db_path, project_id)``.
+    """
+    db_path = tmp_path / "test_theforge.db"
     repo = tmp_path / "repo"
     _init_repo(repo)
-    tasks = [{"id": 1}, {"id": 2}]
-    base = repo / ".forge-worktrees"
 
-    result = _create_isolation_worktrees(tasks, str(repo), base)
+    schema_sql = (REPO_ROOT_REAL / "schema.sql").read_text()
+    conn = sqlite3.connect(db_path)
+    conn.executescript(schema_sql)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO projects (name, codename, local_path) VALUES (?, ?, ?)",
+        ("IsoTest", "isotest", str(repo.resolve())),
+    )
+    project_id = cur.lastrowid
+    conn.commit()
+    conn.close()
 
-    assert set(result.keys()) == {1, 2}
-    assert (base / "task-1").is_dir()
-    assert (base / "task-2").is_dir()
+    monkeypatch.setattr(constants, "THEFORGE_DB", db_path)
+    monkeypatch.setattr(db_mod, "THEFORGE_DB", db_path)
+
+    return repo, db_path, int(project_id)
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+# --- create ---
+
+
+def test_create_happy_path(isolated_env):
+    repo, db_path, project_id = isolated_env
+
+    record = _run(create(1, str(repo)))
+
+    assert record.task_id == 1
+    assert record.project_id == project_id
+    assert record.status == STATUS_ACTIVE
+    assert record.branch == "forge-task-1"
+    assert Path(record.path).is_dir()
+
     branches = _git(repo, "branch", "--list").stdout
     assert "forge-task-1" in branches
-    assert "forge-task-2" in branches
-    out = capsys.readouterr().out
-    assert "[Isolation] Task #1 -> task-1" in out
-    assert "[Isolation] Task #2 -> task-2" in out
+
+    gitignore = (repo / ".gitignore").read_text()
+    assert "forge_worktrees/" in gitignore
 
 
-def test_create_isolation_worktrees_error_path_logs_warning(tmp_path, capsys):
-    """If git can't create worktrees (bare/invalid repo), the helper
-    must log a WARNING and return without the failed task — never crash
-    or silently swallow the error.
-    """
-    not_a_repo = tmp_path / "not_a_repo"
-    not_a_repo.mkdir()
-    base = not_a_repo / ".forge-worktrees"
+def test_create_duplicate_raises(isolated_env):
+    repo, _, _ = isolated_env
 
-    result = _create_isolation_worktrees([{"id": 99}], str(not_a_repo), base)
-
-    assert 99 not in result
-    out = capsys.readouterr().out
-    assert "WARNING" in out
-    assert "task #99" in out
+    _run(create(2, str(repo)))
+    with pytest.raises(WorktreeError, match="already exists"):
+        _run(create(2, str(repo)))
 
 
-# --- _merge_task_branch ---
+def test_create_orphan_branch_recovery(isolated_env):
+    """If a branch exists from a prior failed run but the worktree path is
+    gone, create() should delete the orphan branch and succeed."""
+    repo, _, _ = isolated_env
+
+    _git(repo, "branch", "forge-task-3")
+
+    record = _run(create(3, str(repo)))
+    assert record.status == STATUS_ACTIVE
+    assert Path(record.path).is_dir()
 
 
-def test_merge_task_branch_happy_path(tmp_path, capsys):
-    repo = tmp_path / "repo"
-    _init_repo(repo)
-    base = repo / ".forge-worktrees"
-    _create_isolation_worktrees([{"id": 7}], str(repo), base)
-    capsys.readouterr()  # clear setup output
+# --- merge_back ---
 
-    wt = base / "task-7"
+
+def test_merge_back_happy_path(isolated_env):
+    repo, _, _ = isolated_env
+    record = _run(create(10, str(repo)))
+
+    wt = Path(record.path)
     (wt / "feature.txt").write_text("hello\n")
     _git(wt, "add", "feature.txt")
     _git(wt, "commit", "-m", "feat: add feature")
 
     pre_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
-    ok = _merge_task_branch(str(repo), 7, "forge-task-7")
+    result = _run(merge_back(10))
     post_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
-    assert ok is True
+    assert result.ok is True
     assert pre_head != post_head
-    out = capsys.readouterr().out
-    assert "Merged task #7 into main" in out
+    assert (repo / "feature.txt").exists()
+
+    conn = sqlite3.connect(isolated_env[1])
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status FROM worktrees WHERE task_id = ?", (10,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_MERGED
 
 
-def test_merge_task_branch_no_commits_returns_false(tmp_path, capsys):
-    """A worktree with zero new commits must be skipped (False) and
-    explicitly logged as 'NO commits ahead' — never silently treated as
-    success.
-    """
-    repo = tmp_path / "repo"
-    _init_repo(repo)
-    base = repo / ".forge-worktrees"
-    _create_isolation_worktrees([{"id": 5}], str(repo), base)
-    capsys.readouterr()
+def test_merge_back_no_commits(isolated_env):
+    """A worktree with zero new commits should report ok=True with a
+    'nothing to merge' message — not a failure."""
+    repo, _, _ = isolated_env
+    _run(create(11, str(repo)))
 
-    ok = _merge_task_branch(str(repo), 5, "forge-task-5")
+    result = _run(merge_back(11))
 
-    assert ok is False
-    out = capsys.readouterr().out
-    assert "NO commits ahead of HEAD" in out
+    assert result.ok is True
+    assert "no commits" in result.message.lower()
 
 
-def test_merge_task_branch_missing_branch_logs_explicitly(tmp_path, capsys):
-    """A nonexistent branch is still a failure that must be logged —
-    not silently swallowed (the bug class behind open question #332).
-    """
-    repo = tmp_path / "repo"
-    _init_repo(repo)
-
-    ok = _merge_task_branch(str(repo), 42, "forge-task-does-not-exist")
-
-    assert ok is False
-    out = capsys.readouterr().out
-    # Either "NO commits" (git log returns empty) or an explicit error log
-    # — what matters is the helper does NOT silently return True.
-    assert "task #42" in out or "forge-task-does-not-exist" in out
+def test_merge_back_no_active_worktree(isolated_env):
+    result = _run(merge_back(999))
+    assert result.ok is False
+    assert "No active worktree" in result.message
 
 
-# --- _cleanup_worktrees ---
+# --- destroy ---
 
 
-def test_cleanup_worktrees_deletes_merged_preserves_unmerged(tmp_path, capsys):
-    repo = tmp_path / "repo"
-    _init_repo(repo)
-    base = repo / ".forge-worktrees"
-    worktree_dirs = _create_isolation_worktrees(
-        [{"id": 10}, {"id": 11}], str(repo), base,
-    )
-    capsys.readouterr()
+def test_destroy_removes_worktree_and_branch(isolated_env):
+    repo, db_path, _ = isolated_env
+    record = _run(create(20, str(repo)))
 
-    # Pretend task 10 merged, task 11 did not.
-    _cleanup_worktrees(str(repo), worktree_dirs, {10}, base)
+    _run(destroy(20))
+
+    assert not Path(record.path).exists()
+    branches = _git(repo, "branch", "--list").stdout
+    assert "forge-task-20" not in branches
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status FROM worktrees WHERE task_id = ?", (20,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_ABANDONED
+
+
+def test_destroy_keep_branch(isolated_env):
+    repo, _, _ = isolated_env
+    _run(create(21, str(repo)))
+
+    _run(destroy(21, keep_branch=True))
 
     branches = _git(repo, "branch", "--list").stdout
-    assert "forge-task-10" not in branches  # merged → deleted
-    assert "forge-task-11" in branches      # unmerged → preserved
-    out = capsys.readouterr().out
-    assert "Keeping branch 'forge-task-11'" in out
-    assert not (base / "task-10").exists()
-    assert not (base / "task-11").exists()
+    assert "forge-task-21" in branches
 
 
-def test_cleanup_worktrees_stashes_uncommitted_on_unmerged_branch(
-    tmp_path, capsys,
-):
-    """Regression for task #2158 — when an early_terminated agent leaves
-    uncommitted file changes in its worktree, cleanup must stash them on
+def test_destroy_stashes_uncommitted_work(isolated_env):
+    """Regression for task #2158 — when an early-terminated agent leaves
+    uncommitted file changes in its worktree, destroy() must stash them on
     the branch BEFORE ``git worktree remove --force`` discards them.
     """
-    repo = tmp_path / "repo"
-    _init_repo(repo)
-    base = repo / ".forge-worktrees"
-    worktree_dirs = _create_isolation_worktrees(
-        [{"id": 30}], str(repo), base,
-    )
-    wt_path = Path(worktree_dirs[30])
+    repo, _, _ = isolated_env
+    record = _run(create(30, str(repo)))
+    wt = Path(record.path)
 
-    # Simulate 32 turns of edits the agent never got to commit.
-    (wt_path / "modified.py").write_text("print('important work')\n")
-    _git(wt_path, "add", "modified.py")
-    (wt_path / "untracked.txt").write_text("untracked but valuable\n")
+    (wt / "modified.py").write_text("print('important work')\n")
+    _git(wt, "add", "modified.py")
+    (wt / "untracked.txt").write_text("untracked but valuable\n")
 
-    capsys.readouterr()
-    # Empty merged_tasks set → task 30 is unmerged → must stash.
-    _cleanup_worktrees(str(repo), worktree_dirs, set(), base)
+    _run(destroy(30, keep_branch=True))
 
-    out = capsys.readouterr().out
-    assert "stashed uncommitted work" in out
-    assert "task-30" in out
+    assert not wt.exists()
 
-    # Verify the stash actually exists on the preserved branch.
     stash_list = _git(repo, "stash", "list").stdout
     assert "equipa-early-term task-30" in stash_list
 
-    # Branch is preserved even though work is stashed.
     branches = _git(repo, "branch", "--list").stdout
     assert "forge-task-30" in branches
 
 
-def test_cleanup_worktrees_no_stash_when_clean(tmp_path, capsys):
+def test_destroy_no_stash_when_clean(isolated_env):
     """If the worktree has no uncommitted changes, do NOT create an
-    empty stash — keeps the stash list noise-free.
-    """
-    repo = tmp_path / "repo"
-    _init_repo(repo)
-    base = repo / ".forge-worktrees"
-    worktree_dirs = _create_isolation_worktrees(
-        [{"id": 31}], str(repo), base,
-    )
-    capsys.readouterr()
-    _cleanup_worktrees(str(repo), worktree_dirs, set(), base)
+    empty stash."""
+    repo, _, _ = isolated_env
+    _run(create(31, str(repo)))
+
+    _run(destroy(31, keep_branch=True))
 
     stash_list = _git(repo, "stash", "list").stdout
     assert "task-31" not in stash_list
 
 
-def test_cleanup_worktrees_logs_errors_explicitly(tmp_path, capsys):
-    """If git operations fail (e.g. invalid project_dir), the cleanup
-    helper must LOG the error — the original code's
-    ``except Exception: pass`` is exactly the bug we are fixing.
-    """
-    repo = tmp_path / "repo"
-    _init_repo(repo)
-    base = repo / ".forge-worktrees"
-    worktree_dirs = _create_isolation_worktrees(
-        [{"id": 20}], str(repo), base,
-    )
-    capsys.readouterr()
+# --- mark_failed / mark_conflict ---
 
-    # Point cleanup at a nonexistent project_dir → subprocess.run with
-    # cwd=bad_dir raises FileNotFoundError. The helper must catch it and
-    # LOG explicitly (not silently `pass` like the pre-refactor code).
-    bad_dir = str(tmp_path / "definitely-not-a-repo")
-    _cleanup_worktrees(bad_dir, worktree_dirs, set(), base)
 
-    out = capsys.readouterr().out
-    # Helper must produce an explicit "Cleanup error" log line — this is
-    # the exact behavior change vs. the old `except Exception: pass`.
-    assert "Cleanup error for task #20" in out
-    assert "forge-task-20" in out
+def test_mark_failed(isolated_env):
+    repo, db_path, _ = isolated_env
+    record = _run(create(40, str(repo)))
+
+    _run(mark_failed(40))
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status, ended_at FROM worktrees WHERE task_id = ?", (40,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_FAILED
+    assert row["ended_at"] is not None
+    assert Path(record.path).is_dir()
+
+
+def test_mark_conflict(isolated_env):
+    repo, db_path, _ = isolated_env
+    _run(create(41, str(repo)))
+
+    _run(mark_conflict(41, MergeResult(ok=False, message="test conflict")))
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status FROM worktrees WHERE task_id = ?", (41,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_CONFLICT
+
+
+# --- list_active ---
+
+
+def test_list_active(isolated_env):
+    repo, _, project_id = isolated_env
+    _run(create(50, str(repo)))
+    _run(create(51, str(repo)))
+    _run(mark_failed(51))
+
+    active = _run(list_active(project_id))
+    assert len(active) == 1
+    assert active[0].task_id == 50
+
+
+# --- TaskWorkspace ---
+
+
+def test_task_workspace_success_merges_and_destroys(isolated_env):
+    repo, db_path, _ = isolated_env
+
+    async def _run_ws():
+        async with TaskWorkspace(60, str(repo), isolate=True) as ws:
+            wt = Path(ws.path)
+            assert wt != repo
+            (wt / "ws_feature.txt").write_text("from workspace\n")
+            _git(wt, "add", "ws_feature.txt")
+            _git(wt, "commit", "-m", "workspace commit")
+            ws.set_success(True)
+
+    _run(_run_ws())
+
+    assert (repo / "ws_feature.txt").exists()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status FROM worktrees WHERE task_id = ?", (60,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_MERGED
+
+
+def test_task_workspace_failure_retains_worktree(isolated_env):
+    repo, db_path, _ = isolated_env
+
+    async def _run_ws():
+        async with TaskWorkspace(61, str(repo), isolate=True) as ws:
+            (Path(ws.path) / "wip.txt").write_text("work in progress\n")
+
+    _run(_run_ws())
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status, path FROM worktrees WHERE task_id = ?", (61,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_FAILED
+    assert Path(row["path"]).is_dir()
+
+
+def test_task_workspace_exception_marks_failed(isolated_env):
+    repo, db_path, _ = isolated_env
+
+    async def _run_ws():
+        async with TaskWorkspace(62, str(repo), isolate=True) as ws:
+            raise RuntimeError("agent crashed")
+
+    with pytest.raises(RuntimeError, match="agent crashed"):
+        _run(_run_ws())
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT status FROM worktrees WHERE task_id = ?", (62,),
+    ).fetchone()
+    conn.close()
+    assert row["status"] == STATUS_FAILED
+
+
+def test_task_workspace_no_isolation(isolated_env):
+    repo, _, _ = isolated_env
+
+    async def _run_ws():
+        async with TaskWorkspace(63, str(repo), isolate=False) as ws:
+            assert ws.path == str(repo)
+
+    _run(_run_ws())
+
+
+def test_task_workspace_non_git_dir_falls_back(tmp_path, isolated_env):
+    """A non-git directory should fall back to non-isolated mode."""
+    not_a_repo = tmp_path / "not_a_repo"
+    not_a_repo.mkdir()
+
+    async def _run_ws():
+        async with TaskWorkspace(64, str(not_a_repo), isolate=True) as ws:
+            assert ws.path == str(not_a_repo)
+            assert ws.isolate is False
+
+    _run(_run_ws())


### PR DESCRIPTION
## Summary
- **Phase 1**: Extracts 5 inline worktree helpers from `dispatch.py` into canonical `equipa/worktree_manager.py` shared by both `--worktree` (single-task) and `--tasks` (parallel) dispatch. Adds v12 DB migration (`worktrees` table + `agent_runs.worktree_path`), `--worktree` CLI flag, `TaskWorkspace` async context manager, stash-before-destroy safety net
- **Phase 2**: Per-project file lock (`filelock`) around `merge_back()` serializes concurrent merges from parallel dispatch or multiple CLI invocations. Non-blocking acquire with async polling avoids cross-thread lock/unlock issues on Windows
- **Phase 3**: `--cleanup-worktrees` CLI command for batch cleanup of failed/abandoned worktrees. Lists stale worktrees, stashes uncommitted work, removes directories, deletes branches. Supports `--dry-run` and `--only-project` filtering

## Test plan
- [x] `pytest tests/test_dispatch_isolation_helpers.py` — 28/28 pass
- [x] Full test suite — no regressions (1367 passed; pre-existing failures unchanged)
- [ ] Manual: `python forge_orchestrator.py --task <id> --worktree --dev-test -y` on a real project
- [ ] Manual: `python forge_orchestrator.py --tasks 1,2 --dev-test -y` parallel dispatch still isolates
- [ ] Manual: `python forge_orchestrator.py --cleanup-worktrees --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)