### PR TITLE
Windows portability: test-suite collection + initiative_runner runtime

### DIFF
--- a/equipa/initiative.py
+++ b/equipa/initiative.py
@@ -329,7 +329,7 @@ class InitiativePlan:
         path = cls.plan_path(repo_path, initiative_id)
         if not path.exists():
             raise FileNotFoundError(f"Initiative plan not found: {path}")
-        return cls(path=path, initiative_id=initiative_id, raw_text=path.read_text())
+        return cls(path=path, initiative_id=initiative_id, raw_text=path.read_text(encoding="utf-8"))
 
     @classmethod
     def ensure_exists(
@@ -448,7 +448,7 @@ class InitiativePlan:
         lock_path = self._lock_path(self.path)
         with _acquire_lock(lock_path):
             # Re-read inside the lock so we don't clobber a sibling append.
-            current = self.path.read_text() if self.path.exists() else self.raw_text
+            current = self.path.read_text(encoding="utf-8") if self.path.exists() else self.raw_text
             updated = _insert_before_end_marker(current, entry)
             _atomic_write(self.path, updated)
             self.raw_text = updated
@@ -606,7 +606,10 @@ def _atomic_write(path: Path, content: str) -> None:
         dir=str(path.parent),
     )
     try:
-        with os.fdopen(fd, "w") as fh:
+        # encoding="utf-8" (not the platform default, which is cp1252 on
+        # Windows): the plan carries untrusted, possibly non-Latin/bidi content,
+        # so it must round-trip as UTF-8 on every platform.
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(content)
             fh.flush()
             os.fsync(fh.fileno())

--- a/equipa/initiative_runner.py
+++ b/equipa/initiative_runner.py
@@ -75,6 +75,24 @@ except ImportError:  # Windows
         _msvcrt.locking(fh.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
+def _user_token() -> str:
+    """Stable per-user token for namespacing the last-resort tmp lock dir (N3).
+
+    POSIX uses the numeric uid (``os.getuid``). Windows has no ``getuid``, so we
+    fall back to the sanitized login name. Either way the tmp lock dir stays
+    per-user, so another local user cannot pre-create or hijack it.
+    """
+    import os
+
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None:
+        return str(getuid())
+    import getpass
+
+    name = getpass.getuser() or "unknown"
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+
+
 # Task statuses the runner treats as "still needs work" when selecting the
 # sub-tasks of an initiative on a NORMAL resume. ``in_progress`` is
 # deliberately excluded (S3): a task left ``in_progress`` is almost always a
@@ -582,7 +600,7 @@ def _initiative_lock_dir(repo_path: str | Path) -> Path:
         candidates.append(Path(xdg) / "equipa")
     candidates.append(Path(repo_path) / ".git" / "equipa-locks")
     candidates.append(
-        Path(tempfile.gettempdir()) / f"equipa-locks-{os.getuid()}"
+        Path(tempfile.gettempdir()) / f"equipa-locks-{_user_token()}"
     )
 
     for candidate in candidates:
@@ -989,7 +1007,7 @@ def _active_pause_marker(
         path = InitiativePlan.plan_path(Path(repo_path), initiative_id)
         if not path.exists():
             return None
-        markers = parse_pause_markers(path.read_text())
+        markers = parse_pause_markers(path.read_text(encoding="utf-8"))
     except OSError:
         logger.exception(
             "Failed to read plan file for pause markers (initiative=%s)",

--- a/equipa/initiative_runner.py
+++ b/equipa/initiative_runner.py
@@ -33,7 +33,6 @@ Copyright 2026 Forgeborn
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import logging
 import re
 import sqlite3
@@ -46,6 +45,34 @@ from equipa.initiative import BEGIN_MARKER, InitiativePlan, _sanitize_agent_text
 from equipa.security import _make_untrusted_delimiter, wrap_untrusted
 
 logger = logging.getLogger(__name__)
+
+
+# --- Cross-platform advisory file locking -------------------------------------
+# The initiative concurrency guard takes an exclusive, non-blocking lock and is
+# deliberately fail-CLOSED: if the lock is already held it raises OSError, which
+# the caller converts to InitiativeLockError and refuses to dispatch. POSIX uses
+# fcntl.flock; Windows (no fcntl) uses msvcrt.locking. Both raise OSError on
+# contention, preserving the fail-closed semantics on every platform.
+try:
+    import fcntl as _fcntl
+
+    def _lock_exclusive_nonblocking(fh) -> None:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+
+    def _unlock(fh) -> None:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+except ImportError:  # Windows
+    import msvcrt as _msvcrt
+
+    def _lock_exclusive_nonblocking(fh) -> None:
+        fh.seek(0)
+        # Lock 1 byte at offset 0 (region may extend past EOF on Windows).
+        # LK_NBLCK = exclusive, non-blocking; raises OSError if already held.
+        _msvcrt.locking(fh.fileno(), _msvcrt.LK_NBLCK, 1)
+
+    def _unlock(fh) -> None:
+        fh.seek(0)
+        _msvcrt.locking(fh.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
 # Task statuses the runner treats as "still needs work" when selecting the
@@ -627,7 +654,7 @@ def _initiative_lock(
         ) from exc
     try:
         try:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            _lock_exclusive_nonblocking(fh)
         except OSError as exc:
             raise InitiativeLockError(
                 f"Initiative #{initiative_id} already has a live run "
@@ -636,7 +663,7 @@ def _initiative_lock(
         try:
             yield
         finally:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            _unlock(fh)
     finally:
         fh.close()
 

--- a/forgesmith_simba.py
+++ b/forgesmith_simba.py
@@ -1,1 +1,0 @@
-scripts/forgesmith_simba.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,16 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Also expose scripts/ so modules relocated there during repo cleanup (e.g.
+# forgesmith_simba, forgesmith_impact) import by bare name in tests, exactly as
+# forgesmith.py already arranges them at runtime. This makes `from
+# forgesmith_simba import ...` resolve to scripts/forgesmith_simba.py on every
+# platform, with no reliance on the repo-root symlink that Windows checkouts
+# (core.symlinks=false) materialize as a broken text file.
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
+if _SCRIPTS_DIR.is_dir():
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
 
 def _ensure_full_schema():
     """Apply schema.sql to the test database, creating any missing tables.

--- a/tests/test_initiative_lock_portable.py
+++ b/tests/test_initiative_lock_portable.py
@@ -1,0 +1,44 @@
+"""Cross-platform advisory-lock primitives in equipa.initiative_runner.
+
+The initiative concurrency guard is fail-CLOSED: an already-held lock must raise
+OSError so the caller refuses to dispatch. These tests assert that contract on
+whatever platform they run (fcntl on POSIX, msvcrt on Windows), guarding the
+Windows-portability fix from regressing.
+"""
+
+import os
+
+from equipa import initiative_runner as ir
+
+
+def test_module_imports_on_this_platform():
+    # Regression: a bare top-level `import fcntl` made this module fail to import
+    # on Windows, breaking collection of every test that touched it.
+    assert hasattr(ir, "_lock_exclusive_nonblocking")
+    assert hasattr(ir, "_unlock")
+
+
+def test_exclusive_lock_blocks_second_holder_then_releases(tmp_path):
+    lock_path = tmp_path / "x.lock"
+    fh1 = open(lock_path, "w")
+    fh2 = open(lock_path, "w")
+    try:
+        ir._lock_exclusive_nonblocking(fh1)  # first holder wins
+
+        # Second, non-blocking acquisition must fail closed (OSError).
+        try:
+            ir._lock_exclusive_nonblocking(fh2)
+            raised = False
+        except OSError:
+            raised = True
+        assert raised, "second exclusive lock must raise OSError (fail-closed)"
+
+        # After release, the second holder can acquire.
+        ir._unlock(fh1)
+        ir._lock_exclusive_nonblocking(fh2)
+        ir._unlock(fh2)
+    finally:
+        fh1.close()
+        fh2.close()
+        # sanity: file still exists and is removable
+        assert os.path.exists(lock_path)

--- a/tests/test_initiative_phase2.py
+++ b/tests/test_initiative_phase2.py
@@ -268,7 +268,8 @@ def _write_plan(repo: Path, iid: int, *, pause_reason: str | None) -> None:
     if pause_reason is not None:
         human += f'<!-- pause-for-review reason="{pause_reason}" -->\n\n'
     plan.write_text(
-        human + f"{HUMAN_EDIT_HINT}\n{BEGIN_MARKER}\n\n{END_MARKER}\n"
+        human + f"{HUMAN_EDIT_HINT}\n{BEGIN_MARKER}\n\n{END_MARKER}\n",
+        encoding="utf-8",
     )
 
 
@@ -633,10 +634,16 @@ def test_n2_lock_dir_is_private_not_world_tmp(tmp_path: Path, monkeypatch) -> No
     (repo / ".git").mkdir(parents=True)
     lock_dir = ir._initiative_lock_dir(str(repo))
     # Falls back to the repo's .git dir (not /tmp) when XDG_RUNTIME_DIR unset.
+    # This location check is the cross-platform privacy property (the dir lives
+    # under the user-owned repo, never a world-shared /tmp).
     assert lock_dir == repo / ".git" / "equipa-locks"
     assert lock_dir.is_dir()
-    # Restrictive perms: owner-only.
-    assert (lock_dir.stat().st_mode & 0o777) == 0o700
+    # Restrictive perms: owner-only. POSIX mode bits only — on Windows chmod()
+    # does not set the 0o777 group/other bits (privacy is provided by NTFS ACLs
+    # inherited from the user profile + the per-user location above), so the
+    # numeric-mode assertion is POSIX-only.
+    if sys.platform != "win32":
+        assert (lock_dir.stat().st_mode & 0o777) == 0o700
 
 
 def test_n2_lock_dir_prefers_xdg_runtime(tmp_path: Path, monkeypatch) -> None:
@@ -686,7 +693,8 @@ def test_s4_active_marker_keyed_on_position(tmp_path: Path) -> None:
         '<!-- pause-for-review reason="dup" -->\n'
         "x\n"
         '<!-- pause-for-review reason="dup" -->\n'
-        f"{BEGIN_MARKER}\n{END_MARKER}\n"
+        f"{BEGIN_MARKER}\n{END_MARKER}\n",
+        encoding="utf-8",
     )
     seen: set[tuple[int, str]] = set()
     first = ir._active_pause_marker(str(tmp_path), iid, seen)


### PR DESCRIPTION
Makes Equipa's test suite collect and the initiative subsystem run on Windows. Independent of #17 (both branch off the same up-to-date `main`); on Linux these changes are effectively no-ops that also enable Windows, so Linux CI is unaffected.

The updated `main` had never been run on Windows; this fixes a chain of Linux-only assumptions. Each is a root-cause fix, not a symptom patch.

## Collection blockers (broke `pytest` collection on Windows)

1. **Root `forgesmith_simba.py` was a Git symlink** → `scripts/forgesmith_simba.py`. With `core.symlinks=false` (the Windows default) Git materializes it as a plain text file whose body is the link target — invalid Python (`NameError: name 'scripts' is not defined`), which broke collection of every test transitively importing `forgesmith`. It also masked a latent real-dispatch crash: `prompts.py` guards that import with `except ImportError`, which does **not** catch a `NameError`.
   Fix: expose `scripts/` on `sys.path` in `tests/conftest.py` — the same arrangement `forgesmith.py` already makes at runtime — and remove the root symlink. `from forgesmith_simba import …` now resolves to `scripts/forgesmith_simba.py` as a single module on every platform, so existing mocks keep working.

2. **`equipa/initiative_runner.py` did a top-level `import fcntl`** (Unix-only) → `ModuleNotFoundError` on Windows. Replaced with a cross-platform exclusive advisory lock (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows). The guard is fail-CLOSED (contention raises `OSError` → caller refuses to dispatch); both backends preserve that, covered by `tests/test_initiative_lock_portable.py`.

## initiative_runner runtime (surfaced once the module could import)

3. **`os.getuid()`** (Unix-only) namespaced the last-resort tmp lock dir and was built eagerly for every candidate, so it crashed on Windows even when the `.git` candidate would win. Added `_user_token()`: numeric uid on POSIX, sanitized login name on Windows — preserves the per-user namespacing (N3).

4. **Plan file I/O used the platform default encoding** (cp1252 on Windows). The plan carries untrusted, possibly non-Latin/bidi content, so reading/writing it on Windows corrupted data or raised `UnicodeEncodeError`. Pinned `encoding="utf-8"` on the atomic write and all three plan reads (plus the test plan writers).

5. **A lock-dir test asserted POSIX mode bits** (`st_mode & 0o777 == 0o700`). Windows `chmod()` doesn't set group/other bits (privacy comes from NTFS ACLs + the per-user location). Guarded the numeric-mode assertion to POSIX; the cross-platform location/privacy checks stay active everywhere.

## Verification (on Windows)
- Full-suite **collection: 0 errors** when `dspy` is installed. (Without `dspy`, 5 files still error at collection on `class RolePromptModule(dspy.Module)` — that's an *optional-dependency* crash, not a Windows issue; it's fixed independently in #17. Not in scope here.)
- initiative phase2 / phase2_1 / lock tests: **43 passed**. Broad unit regression: **212 passed**.

## Out of scope (documented, deliberately not Band-Aided)
`skills/security/modern-python/hooks/shims/{pip3,python3}` are also Git symlinks that Windows mis-materializes. But that entire shim subsystem is **Unix-by-design** — `#!/usr/bin/env bash` scripts, a `setup-shims.sh` that prepends `PATH` via `CLAUDE_ENV_FILE`, a `bash`-invoked SessionStart hook, `.bats` tests. Converting the symlinks to files would mask the symptom without making the mechanism function on Windows (and would regress the Unix multi-call behavior) — a Band-Aid. Properly supporting it on Windows is a separate port of the whole subsystem (`.cmd`/`.ps1` wrappers + Windows PATH setup). These files are inert on Windows (not Python imports; the hook simply doesn't run), so they don't affect Equipa core or the test suite. Flagged for a separate decision.
