### PR TITLE
Dispatch by stored tasks.role (single-task + autonomous) — Design Q3

### DIFF
--- a/docs/project-roles.md
+++ b/docs/project-roles.md
@@ -61,3 +61,29 @@ For `early_term_exempt`, a role file's frontmatter value (when set) wins over th
 
 No base-code changes, no merge conflicts on Equipa updates. See
 [`examples/roles/`](../examples/roles/) for ready-to-copy starting points.
+
+## Dispatching by stored role (`tasks.role`)
+
+A task can carry its own dispatch role in the `tasks.role` column. When set, it
+drives dispatch wherever `--role` is not given explicitly:
+
+- **Single task:** `--task <ID>` (no `--role`) uses the task's role; an explicit
+  `--role X` still overrides it.
+- **Autonomous / scan modes:** `--auto-run` and `--project <ID>` dispatch each
+  task with its stored role, so a project can fan work out to specialist or
+  project-overlay roles instead of always running the dev/test loop.
+
+Role-selection precedence: explicit `--role` → `tasks.role` → `developer`.
+
+Report-writer roles (frontmatter `early_term_exempt: true`) skip the tester
+phase when they produce no code diff — the same treatment as the built-in
+reviewer roles.
+
+Set a task's role via the DB / MCP, e.g.:
+
+```sql
+UPDATE tasks SET role = 'scilab-engineer' WHERE id = 100028;
+```
+
+The `tasks.role` column is added automatically on startup (idempotent, additive)
+for existing databases, and is part of `schema.sql` for fresh installs.

--- a/docs/project-roles.md
+++ b/docs/project-roles.md
@@ -1,0 +1,63 @@
+# Project-specific roles
+
+Equipa resolves an agent role by checking a project's private overlay **before** the shared
+base role set. This lets a project define its own roles without editing base Equipa, and keeps
+two projects' same-named roles fully isolated.
+
+## Where roles live (precedence)
+
+For a role named `<role>` dispatched against a project, resolution is:
+
+1. `<project_dir>/.equipa/roles/<role>.md` — the project's private overlay (**wins**)
+2. `<equipa>/prompts/<role>.md` — the shared base role (fallback)
+
+A project overlay **shadows** a base role of the same name, but only for that project.
+
+## Isolation guarantee
+
+Two projects can each define a `cybersecurity-engineer` (or any same-named role) with totally
+different prompts and config. They never interfere:
+
+- Resolution is keyed on the dispatching project's directory.
+- It holds **no process-global mutable role state** — the resolver reads files fresh per call.
+
+This is what makes per-project roles safe under `--auto-run`, which dispatches multiple
+projects concurrently in a single process. Project A's role can never leak into project B.
+
+## Self-describing roles (frontmatter)
+
+A role `.md` may begin with optional frontmatter declaring its own config. Absent frontmatter,
+behavior is identical to the legacy global role set — fully backward-compatible, no base
+`constants.py` edit required.
+
+```markdown
+---
+model: opus              # model tier (else dispatch-config / CLI / defaults)
+turns: 35                # turn budget (else DEFAULT_ROLE_TURNS / DEFAULT_MAX_TURNS)
+effort: high             # reasoning effort hint
+early_term_exempt: true  # exempt from the no-file-change early-termination kill
+skills: [security]       # role skill dirs
+---
+## CRITICAL: Bias for Action
+...the prompt body begins here (frontmatter is stripped before use)...
+```
+
+### Config precedence
+
+For `model` and `turns`, explicit operator overrides still win over a role's own frontmatter:
+
+```
+dispatch-config per-role/complexity  >  CLI --model/--max-turns  >  frontmatter  >  base defaults
+```
+
+For `early_term_exempt`, a role file's frontmatter value (when set) wins over the base
+`EARLY_TERM_EXEMPT_ROLES` set.
+
+## Adding a project role
+
+1. `mkdir -p <project_dir>/.equipa/roles`
+2. Write `<project_dir>/.equipa/roles/<role>.md` (optionally with frontmatter).
+3. Dispatch it: `python forge_orchestrator.py --task <ID> --role <role> -y`.
+
+No base-code changes, no merge conflicts on Equipa updates. See
+[`examples/roles/`](../examples/roles/) for ready-to-copy starting points.

--- a/equipa/agent_runner.py
+++ b/equipa/agent_runner.py
@@ -142,7 +142,6 @@ from equipa.abort_controller import AbortController, create_child_abort_controll
 from equipa.bash_security import check_bash_command
 from equipa.config import is_feature_enabled, load_dispatch_config
 from equipa.constants import (
-    EARLY_TERM_EXEMPT_ROLES,
     EARLY_TERM_FINAL_WARN_TURNS,
     EARLY_TERM_KILL_TURNS,
     EARLY_TERM_WARN_TURNS,
@@ -694,7 +693,8 @@ async def _run_agent_streaming_impl(
     """
     effective_timeout = timeout or PROCESS_TIMEOUT
     start_time = time.time()
-    is_exempt = role in EARLY_TERM_EXEMPT_ROLES
+    from equipa.role_resolver import is_role_early_term_exempt
+    is_exempt = is_role_early_term_exempt(role, project_dir)
 
     # Task #2314 Phase A3: capture HEAD before any agent work so that the
     # post-run git-diff cross-check measures ONLY commits this cycle made.
@@ -1755,7 +1755,8 @@ async def dispatch_agent(
                 }
 
     # Default: Claude via run_agent_streaming (with retry wrapper)
-    use_streaming = role not in EARLY_TERM_EXEMPT_ROLES
+    from equipa.role_resolver import is_role_early_term_exempt
+    use_streaming = not is_role_early_term_exempt(role, project_dir)
     if use_streaming:
         # Wrap streaming with retry logic
         return await run_agent_streaming_with_retry(

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -22,7 +22,6 @@ from equipa.constants import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_MAX_TURNS,
     DEFAULT_MODEL,
-    EARLY_TERM_EXEMPT_ROLES,
     MAX_DEV_TEST_CYCLES,
     MAX_MANAGER_ROUNDS,
     MCP_CONFIG,
@@ -1649,7 +1648,8 @@ async def run_mode_task(args: argparse.Namespace) -> None:
 
     else:
         # Single-agent mode (Phase 1 — with model tiering)
-        use_streaming = args.role not in EARLY_TERM_EXEMPT_ROLES
+        from equipa.role_resolver import is_role_early_term_exempt
+        use_streaming = not is_role_early_term_exempt(args.role, project_dir)
         role_turns_max = get_role_turns(args.role, args, task=task)
         role_model = get_role_model(args.role, args, task=task)
         # Dynamic budget for single-agent mode

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -597,8 +597,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         f.stem for f in prompts_dir.glob("*.md")
         if not f.name.startswith("_")
     ]) if prompts_dir.exists() else ["developer", "tester", "security-reviewer"]
-    parser.add_argument("--role", default="developer", choices=_available_roles,
-                        help=f"Agent role (available: {', '.join(_available_roles)}) (default: developer)")
+    # NOTE: no argparse `choices=` here. Project-overlay roles
+    # (<project_dir>/.equipa/roles/) are unknown at parse time because the
+    # project dir is only known after a task is resolved, so a hard choices list
+    # would reject valid project roles. The role is validated post-parse against
+    # the project-aware resolver (see run_mode_task) and by build_system_prompt.
+    parser.add_argument("--role", default="developer",
+                        help=f"Agent role. Base roles: {', '.join(_available_roles)}. "
+                             f"Project roles in <project_dir>/.equipa/roles/ are also accepted. "
+                             f"(default: developer)")
     parser.add_argument("--retries", type=int, default=DEFAULT_MAX_RETRIES, help=f"Max retry attempts (default: {DEFAULT_MAX_RETRIES})")
     parser.add_argument("--dev-test", action="store_true", help="Enable Dev+Tester iteration loop mode")
     parser.add_argument("--security-review", action="store_true", default=None,
@@ -1319,6 +1326,17 @@ async def run_mode_task(args: argparse.Namespace) -> None:
         print(f"ERROR: Could not find project directory for '{task.get('project_name', 'Unknown')}'")
         print("Known projects:", ", ".join(sorted(_equipa_constants.PROJECT_DIRS.keys())))
         sys.exit(1)
+
+    # Validate --role now that project_dir is known. argparse can't enforce this
+    # (project-overlay roles in <project_dir>/.equipa/roles/ are unknown at parse
+    # time), so --role accepts any string and we check it project-aware here.
+    role_arg = getattr(args, "role", None)
+    if role_arg:
+        from equipa.role_resolver import role_exists, available_roles
+        if not role_exists(role_arg, project_dir):
+            print(f"ERROR: Unknown role '{role_arg}'. "
+                  f"Available for this project: {', '.join(available_roles(project_dir))}")
+            sys.exit(1)
 
     # Auto-clone ForgeScaffold for empty/missing scaffold-based projects.
     try:

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -602,10 +602,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     # project dir is only known after a task is resolved, so a hard choices list
     # would reject valid project roles. The role is validated post-parse against
     # the project-aware resolver (see run_mode_task) and by build_system_prompt.
-    parser.add_argument("--role", default="developer",
+    # default=None (not "developer") so run_mode_task can tell an explicit
+    # --role from an unset one: explicit wins, else the task's stored role
+    # (tasks.role), else developer.
+    parser.add_argument("--role", default=None,
                         help=f"Agent role. Base roles: {', '.join(_available_roles)}. "
                              f"Project roles in <project_dir>/.equipa/roles/ are also accepted. "
-                             f"(default: developer)")
+                             f"If unset, the task's stored role (tasks.role) is used, else developer.")
     parser.add_argument("--retries", type=int, default=DEFAULT_MAX_RETRIES, help=f"Max retry attempts (default: {DEFAULT_MAX_RETRIES})")
     parser.add_argument("--dev-test", action="store_true", help="Enable Dev+Tester iteration loop mode")
     parser.add_argument("--security-review", action="store_true", default=None,
@@ -1327,16 +1330,19 @@ async def run_mode_task(args: argparse.Namespace) -> None:
         print("Known projects:", ", ".join(sorted(_equipa_constants.PROJECT_DIRS.keys())))
         sys.exit(1)
 
-    # Validate --role now that project_dir is known. argparse can't enforce this
-    # (project-overlay roles in <project_dir>/.equipa/roles/ are unknown at parse
-    # time), so --role accepts any string and we check it project-aware here.
-    role_arg = getattr(args, "role", None)
-    if role_arg:
-        from equipa.role_resolver import role_exists, available_roles
-        if not role_exists(role_arg, project_dir):
-            print(f"ERROR: Unknown role '{role_arg}'. "
-                  f"Available for this project: {', '.join(available_roles(project_dir))}")
-            sys.exit(1)
+    # Resolve the effective dispatch role now that the task (and its project)
+    # is known: an explicit --role wins; else the task's stored role
+    # (tasks.role); else developer. Set args.role so every downstream consumer
+    # sees the resolved value. Then validate it project-aware — argparse can't,
+    # because project-overlay roles (<project_dir>/.equipa/roles/) are unknown
+    # at parse time, so --role accepts any string and we check it here.
+    if not getattr(args, "role", None):
+        args.role = (task.get("role") or "developer")
+    from equipa.role_resolver import role_exists, available_roles
+    if not role_exists(args.role, project_dir):
+        print(f"ERROR: Unknown role '{args.role}'. "
+              f"Available for this project: {', '.join(available_roles(project_dir))}")
+        sys.exit(1)
 
     # Auto-clone ForgeScaffold for empty/missing scaffold-based projects.
     try:

--- a/equipa/db.py
+++ b/equipa/db.py
@@ -179,6 +179,8 @@ def ensure_schema() -> None:
     try:
         conn.executescript(schema_sql)
         conn.commit()
+        _ensure_additive_columns(conn)
+        conn.commit()
     except sqlite3.Error as e:
         logger.exception("[Schema] Failed to apply schema.sql: %s", e)
         raise SchemaNotInitialised(
@@ -188,6 +190,29 @@ def ensure_schema() -> None:
         conn.close()
 
     _SCHEMA_ENSURED = True
+
+
+def _ensure_additive_columns(conn) -> None:
+    """Add nullable columns that post-date a table's CREATE in existing DBs.
+
+    ``ensure_schema`` applies ``schema.sql`` with CREATE TABLE IF NOT EXISTS,
+    which is a no-op for tables that already exist — so a column added to a
+    table definition *after* that table was first created never reaches an
+    existing database. SQLite has no ``ALTER TABLE ... ADD COLUMN IF NOT
+    EXISTS``, so we check ``PRAGMA table_info`` and add only what is missing.
+    Idempotent, additive (nullable, no data change), and independent of the
+    ``db_migrate`` version counter — safe to run on every startup.
+    """
+    additive = {
+        # tasks.role lets a task carry its dispatch role so autonomous/scan
+        # modes (and --task without --role) fan out to specialist/project roles.
+        "tasks": [("role", "TEXT")],
+    }
+    for table, cols in additive.items():
+        existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        for name, decl in cols:
+            if name not in existing:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {decl}")
 
 
 # --- Record Functions ---

--- a/equipa/loops.py
+++ b/equipa/loops.py
@@ -1207,14 +1207,29 @@ _AUDIT_ROLES = frozenset({"security-reviewer", "code-reviewer"})
 _AUDIT_TASK_TYPES = frozenset({"audit", "review"})
 
 
-def _is_audit_type_task(task: dict[str, Any] | None, task_role: str) -> bool:
+def _is_audit_type_task(
+    task: dict[str, Any] | None,
+    task_role: str,
+    project_dir: str | None = None,
+) -> bool:
     """Return True if this task's deliverable is a markdown report, not code.
 
-    Triggers on either an audit-style ``task_type`` or one of the reviewer
-    roles. Matches the criteria spelled out in TheForge bug 2237.
+    Triggers on an audit-style ``task_type``, one of the reviewer roles, or a
+    report-writer role (frontmatter ``early_term_exempt`` — e.g. design /
+    ip / regulatory analysts and project-overlay analysis roles), which produce
+    markdown deliverables rather than code. Matches the criteria spelled out in
+    TheForge bug 2237. The caller still guards the short-circuit on an empty git
+    diff, so a role that does emit code keeps its tester cycle.
     """
     if task_role in _AUDIT_ROLES:
         return True
+    if project_dir:
+        try:
+            from equipa.role_resolver import is_role_early_term_exempt
+            if is_role_early_term_exempt(task_role, project_dir):
+                return True
+        except Exception:
+            pass
     if not isinstance(task, dict):
         return False
     return (task.get("task_type") or "") in _AUDIT_TASK_TYPES
@@ -2025,7 +2040,7 @@ async def run_dev_test_loop(
             # there is nothing for the tester to test. Running it anyway either
             # wastes turns in analysis paralysis or returns tester_blocked when
             # the diff is empty. See TheForge bug 2237.
-            if _is_audit_type_task(task, task_role):
+            if _is_audit_type_task(task, task_role, project_dir):
                 diff_empty = await _git_diff_is_empty(project_dir, base_ref=prev_cycle_sha)
                 if diff_empty:
                     md_files = [

--- a/equipa/loops.py
+++ b/equipa/loops.py
@@ -38,7 +38,6 @@ from equipa.constants import (
     COMPACTION_CONSOLIDATION_MAX_WORDS,
     COST_ESTIMATE_PER_TURN,
     COST_LIMITS,
-    EARLY_TERM_EXEMPT_ROLES,
     FINDING_DESCRIPTION_MAX_CHARS,
     MAX_CONTINUATIONS,
     MAX_DEV_TEST_CYCLES,
@@ -1860,7 +1859,8 @@ async def run_dev_test_loop(
                 error_type=state.last_error_type,
                 max_turns=dev_turns_allocated,
             )
-            use_streaming = task_role not in EARLY_TERM_EXEMPT_ROLES
+            from equipa.role_resolver import is_role_early_term_exempt
+            use_streaming = not is_role_early_term_exempt(task_role, project_dir)
             # --- Lifecycle hooks: pre_agent_start ---
             await fire_hook(
                 "pre_agent_start",

--- a/equipa/prompts.py
+++ b/equipa/prompts.py
@@ -373,30 +373,40 @@ def build_system_prompt(
         def get_relevant_lessons(role=None, error_type=None, limit=5):
             return []
 
-    common_path = PROMPTS_DIR / "_common.md"
-    role_path = ROLE_PROMPTS.get(role)
+    from equipa.role_resolver import resolve_role
 
-    if not role_path:
-        print(f"ERROR: Unknown role '{role}'. Available: {', '.join(ROLE_PROMPTS.keys())}")
+    common_path = PROMPTS_DIR / "_common.md"
+
+    # Project-scoped role resolution: a role defined in the dispatching
+    # project's overlay (<project_dir>/.equipa/roles/<role>.md) shadows the base
+    # role of the same name; otherwise the shared base prompt is used. Two
+    # projects' same-named roles never collide — resolution is keyed on
+    # project_dir and holds no process-global state.
+    role_cfg = resolve_role(role, project_dir)
+    if role_cfg is None:
+        avail = ", ".join(sorted(ROLE_PROMPTS.keys()))
+        print(f"ERROR: Unknown role '{role}'. Available base roles: {avail}. "
+              f"Project-specific roles live in <project_dir>/.equipa/roles/.")
         sys.exit(1)
+    role_path = role_cfg.path
+    role_text = role_cfg.body  # frontmatter (if any) already stripped
 
     if not common_path.exists():
         print(f"ERROR: Common prompt not found at {common_path}")
         sys.exit(1)
 
-    if not role_path.exists():
-        print(f"ERROR: Role prompt not found at {role_path}")
-        sys.exit(1)
-
     # A/B prompt version selection: try GEPA-evolved prompt if available
     # Gated by gepa_ab_testing feature flag
+    # GEPA A/B evolution applies only to base roles, not project overlays.
     prompt_version = "baseline"
-    if is_feature_enabled(dispatch_config, "gepa_ab_testing"):
+    if not role_cfg.is_project_role and is_feature_enabled(dispatch_config, "gepa_ab_testing"):
         try:
             from forgesmith_gepa import get_ab_prompt_for_role
+            from equipa.role_resolver import parse_frontmatter
             selected_path, prompt_version = get_ab_prompt_for_role(role)
             if selected_path.exists() and prompt_version != "baseline":
                 role_path = selected_path
+                role_text = parse_frontmatter(selected_path.read_text(encoding="utf-8"))[1]
         except ImportError:
             pass  # forgesmith_gepa not available, use baseline
 
@@ -421,7 +431,7 @@ def build_system_prompt(
     # that would make every dispatch unique and defeat prompt caching.
     # =========================================================================
     common_text = common_path.read_text(encoding="utf-8")
-    role_text = role_path.read_text(encoding="utf-8")
+    # role_text was resolved above (project overlay or base, frontmatter stripped).
     standing_orders = load_standing_orders(role)
     static_prefix = common_text + "\n\n---\n\n" + role_text + standing_orders
 

--- a/equipa/prompts.py
+++ b/equipa/prompts.py
@@ -373,7 +373,7 @@ def build_system_prompt(
         def get_relevant_lessons(role=None, error_type=None, limit=5):
             return []
 
-    from equipa.role_resolver import resolve_role
+    from equipa.role_resolver import resolve_role, available_roles
 
     common_path = PROMPTS_DIR / "_common.md"
 
@@ -384,9 +384,9 @@ def build_system_prompt(
     # project_dir and holds no process-global state.
     role_cfg = resolve_role(role, project_dir)
     if role_cfg is None:
-        avail = ", ".join(sorted(ROLE_PROMPTS.keys()))
-        print(f"ERROR: Unknown role '{role}'. Available base roles: {avail}. "
-              f"Project-specific roles live in <project_dir>/.equipa/roles/.")
+        avail = ", ".join(available_roles(project_dir))
+        print(f"ERROR: Unknown role '{role}'. Available for this project "
+              f"(base + <project_dir>/.equipa/roles/): {avail}.")
         sys.exit(1)
     role_path = role_cfg.path
     role_text = role_cfg.body  # frontmatter (if any) already stripped

--- a/equipa/role_resolver.py
+++ b/equipa/role_resolver.py
@@ -156,3 +156,26 @@ def is_role_early_term_exempt(role: str, project_dir: str | None = None) -> bool
     if rc is not None and rc.early_term_exempt is not None:
         return rc.early_term_exempt
     return role in EARLY_TERM_EXEMPT_ROLES
+
+
+def available_roles(project_dir: str | None = None) -> list[str]:
+    """All dispatchable role names for ``project_dir``: base + project overlay.
+
+    Base roles come from ``prompts/`` (and the discovered ``ROLE_PROMPTS`` dict);
+    project roles come from ``<project_dir>/.equipa/roles/``. Used for helpful
+    "unknown role" error messages, since argparse cannot enumerate project-overlay
+    roles at parse time (the project dir is not known until a task is resolved).
+    """
+    names: set[str] = set()
+    if PROMPTS_DIR.is_dir():
+        for f in PROMPTS_DIR.glob("*.md"):
+            if not f.name.startswith("_"):
+                names.add(f.stem)
+    names.update(_equipa_constants.ROLE_PROMPTS.keys())
+    if project_dir:
+        overlay = Path(project_dir).joinpath(*PROJECT_ROLES_SUBDIR)
+        if overlay.is_dir():
+            for f in overlay.glob("*.md"):
+                if not f.name.startswith("_"):
+                    names.add(f.stem)
+    return sorted(names)

--- a/equipa/role_resolver.py
+++ b/equipa/role_resolver.py
@@ -1,0 +1,158 @@
+"""EQUIPA project-scoped role resolution.
+
+Resolves a role name to its prompt file + config, checking a project's
+private ``<project_dir>/.equipa/roles/`` overlay BEFORE the shared base
+``prompts/`` set.
+
+Isolation guarantee
+-------------------
+Two projects that each define a role of the same name (e.g. both have a
+``cybersecurity-engineer``) are fully isolated: resolution is keyed on the
+dispatching project's directory and holds NO process-global mutable role
+state. This is what makes it safe under ``--auto-run``, which dispatches
+multiple projects concurrently in one process — project A's role can never
+shadow or leak into project B's.
+
+Self-describing roles
+---------------------
+A role ``.md`` may declare its own config via optional frontmatter at the
+top of the file (``model``, ``turns``, ``effort``, ``early_term_exempt``,
+``skills``). Absent frontmatter, behaviour is identical to the legacy
+global role set, so the change is fully backward-compatible — no base
+``constants.py`` edits are required to add a project role.
+
+Copyright 2026 Forgeborn
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import equipa.constants as _equipa_constants
+from equipa.constants import EARLY_TERM_EXEMPT_ROLES, PROMPTS_DIR
+
+# Relative location of a project's private role overlay, joined onto project_dir.
+PROJECT_ROLES_SUBDIR = (".equipa", "roles")
+
+
+@dataclass
+class RoleConfig:
+    """Resolved role: its prompt body (frontmatter stripped) + optional config."""
+
+    name: str
+    path: Path
+    body: str
+    model: str | None = None
+    turns: int | None = None
+    effort: str | None = None
+    early_term_exempt: bool | None = None
+    skills: list[str] = field(default_factory=list)
+    is_project_role: bool = False
+
+
+def _coerce(raw: str):
+    """Coerce a frontmatter scalar/inline-list string to a Python value."""
+    if raw.startswith("[") and raw.endswith("]"):
+        inner = raw[1:-1].strip()
+        if not inner:
+            return []
+        return [p.strip().strip("'\"") for p in inner.split(",") if p.strip()]
+    low = raw.lower()
+    if low in ("true", "false"):
+        return low == "true"
+    if raw.lstrip("-").isdigit():
+        return int(raw)
+    return raw.strip("'\"")
+
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Split an optional leading ``--- ... ---`` frontmatter block from a role file.
+
+    Returns ``(meta, body)``. When no well-formed frontmatter block is present,
+    ``meta`` is empty and ``body`` is the original text unchanged.
+
+    Intentionally minimal (no PyYAML dependency): supports scalar
+    ``key: value`` lines and inline lists ``key: [a, b, c]``. A block without a
+    closing ``---`` fence is treated as ordinary body text, not frontmatter.
+    """
+    if not text.startswith("---"):
+        return {}, text
+    lines = text.splitlines(keepends=True)
+    if lines[0].strip() != "---":
+        return {}, text
+    meta: dict = {}
+    for i in range(1, len(lines)):
+        stripped = lines[i].strip()
+        if stripped == "---":
+            body = "".join(lines[i + 1:])
+            return meta, body.lstrip("\n")
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        key, _, raw = stripped.partition(":")
+        meta[key.strip()] = _coerce(raw.strip())
+    # No closing fence — not frontmatter; treat the whole text as body.
+    return {}, text
+
+
+def _role_file(role: str, project_dir: str | None) -> tuple[Path | None, bool]:
+    """Locate a role's ``.md``: project overlay wins, then the base set.
+
+    Returns ``(path, is_project_role)``; ``(None, False)`` if no file exists.
+    """
+    if project_dir:
+        candidate = Path(project_dir).joinpath(*PROJECT_ROLES_SUBDIR, f"{role}.md")
+        if candidate.is_file():
+            return candidate, True
+    base = _equipa_constants.ROLE_PROMPTS.get(role)
+    if base and Path(base).is_file():
+        return Path(base), False
+    direct = PROMPTS_DIR / f"{role}.md"
+    if direct.is_file():
+        return direct, False
+    return None, False
+
+
+def resolve_role(role: str, project_dir: str | None = None) -> RoleConfig | None:
+    """Resolve ``role`` to a :class:`RoleConfig`, project overlay taking precedence.
+
+    Returns ``None`` when neither a project nor a base file exists for the role.
+    Stateless and side-effect-free: reads files fresh per call and shares no
+    mutable global state, so concurrent resolution for different projects is
+    safe and same-named roles in different projects never interfere.
+    """
+    path, is_project = _role_file(role, project_dir)
+    if path is None:
+        return None
+    meta, body = parse_frontmatter(path.read_text(encoding="utf-8"))
+    turns = meta.get("turns")
+    exempt = meta.get("early_term_exempt")
+    return RoleConfig(
+        name=role,
+        path=path,
+        body=body,
+        model=meta.get("model"),
+        turns=turns if isinstance(turns, int) else None,
+        effort=meta.get("effort"),
+        early_term_exempt=bool(exempt) if isinstance(exempt, bool) else None,
+        skills=list(meta.get("skills") or []),
+        is_project_role=is_project,
+    )
+
+
+def role_exists(role: str, project_dir: str | None = None) -> bool:
+    """True if ``role`` resolves to a project-overlay or base prompt file."""
+    return _role_file(role, project_dir)[0] is not None
+
+
+def is_role_early_term_exempt(role: str, project_dir: str | None = None) -> bool:
+    """Whether ``role`` is exempt from the no-file-change early-termination kill.
+
+    A role file's frontmatter ``early_term_exempt`` (when set) wins; otherwise
+    falls back to the base ``EARLY_TERM_EXEMPT_ROLES`` set, preserving legacy
+    behaviour for built-in roles.
+    """
+    rc = resolve_role(role, project_dir)
+    if rc is not None and rc.early_term_exempt is not None:
+        return rc.early_term_exempt
+    return role in EARLY_TERM_EXEMPT_ROLES

--- a/equipa/roles.py
+++ b/equipa/roles.py
@@ -23,6 +23,23 @@ from equipa.constants import (
 )
 
 
+def _resolve_role_cfg(role: str, task: dict | None):
+    """Best-effort RoleConfig for (role, the task's project). Never raises.
+
+    Resolution is project-aware: a role defined in the task's project overlay
+    (``<project_dir>/.equipa/roles/<role>.md``) shadows the base role of the
+    same name. Returns None if nothing resolves or anything goes wrong, so
+    callers cleanly fall back to base defaults.
+    """
+    try:
+        from equipa.role_resolver import resolve_role
+        from equipa.tasks import resolve_project_dir
+        project_dir = resolve_project_dir(task) if task else None
+        return resolve_role(role, project_dir)
+    except Exception:
+        return None
+
+
 def get_role_turns(
     role: str,
     args: object,
@@ -51,8 +68,15 @@ def get_role_turns(
         if cli_turns != DEFAULT_MAX_TURNS:
             base_turns = cli_turns
         else:
-            # Fall back to per-role defaults
-            base_turns = DEFAULT_ROLE_TURNS.get(role, DEFAULT_MAX_TURNS)
+            # Fall back to per-role defaults. A project role's frontmatter
+            # `turns` (resolved against the task's project) wins over the base
+            # DEFAULT_ROLE_TURNS dict, so project roles tune their budget
+            # without editing base constants.py.
+            rc = _resolve_role_cfg(role, task)
+            if rc and rc.turns:
+                base_turns = rc.turns
+            else:
+                base_turns = DEFAULT_ROLE_TURNS.get(role, DEFAULT_MAX_TURNS)
 
     # Apply complexity multiplier
     if task:
@@ -140,6 +164,12 @@ def get_role_model(
             return routed_model
         raise CircuitOpenError(role=role, tier_attempted="haiku")
 
+    # Frontmatter `model` on a project role is a DEFAULT-level fallback (below
+    # dispatch-config / CLI / auto-routing), letting project roles pick a model
+    # without a base constants.py edit.
+    rc = _resolve_role_cfg(role, task)
+    if rc and rc.model:
+        return rc.model
     return DEFAULT_ROLE_MODELS.get(role, DEFAULT_MODEL)
 
 

--- a/equipa/roles.py
+++ b/equipa/roles.py
@@ -161,7 +161,15 @@ def _discover_roles() -> None:
         discovered[role_name] = md_file
 
     if discovered:
-        _equipa_constants.ROLE_PROMPTS = discovered
+        # Mutate the existing dict in place rather than rebinding the attribute.
+        # Modules like equipa.prompts do `from equipa.constants import ROLE_PROMPTS`,
+        # which snapshots the original dict object at import time. Rebinding
+        # `_equipa_constants.ROLE_PROMPTS` would leave those snapshots pointing at
+        # the stale dict, so file-based role discovery (e.g. design-engineer.md)
+        # would never reach build_system_prompt. Clearing + updating the same
+        # object keeps every importer in sync.
+        _equipa_constants.ROLE_PROMPTS.clear()
+        _equipa_constants.ROLE_PROMPTS.update(discovered)
 
 
 def _accumulate_cost(

--- a/examples/roles/README.md
+++ b/examples/roles/README.md
@@ -1,0 +1,43 @@
+# Example roles (opt-in)
+
+These are **optional** agent roles — they are *not* part of base Equipa's role set and are
+not auto-loaded. They demonstrate the project-scoped role mechanism (see
+[`docs/project-roles.md`](../../docs/project-roles.md)) and are useful starting points for
+hardware / regulated-product work.
+
+| Role | Purpose |
+|------|---------|
+| `design-engineer` | Architecture, trade studies, interface specs for safety-critical/regulated hardware+firmware. |
+| `ip-analyst` | Freedom-to-operate, prior-art, patent-landscape analysis (attorney-grade rigor, **not** legal advice). |
+| `regulatory-analyst` | Standards/compliance applicability, gap analysis, certification-path mapping (**not** legal/PE advice). |
+
+## Using one
+
+Copy the role into either location — the same precedence rules apply as any role:
+
+- **One project only:** drop it in `<project_dir>/.equipa/roles/`. It is then private to that
+  project and isolated from any same-named role in another project.
+- **All projects:** drop it in base `prompts/`. It becomes a globally-available role.
+
+Then dispatch it like any role:
+
+```bash
+python forge_orchestrator.py --task <ID> --role design-engineer -y
+```
+
+## Frontmatter
+
+Each file carries optional frontmatter declaring its own config, so no `constants.py` edit is
+needed:
+
+```markdown
+---
+model: opus            # model tier; falls back to defaults if omitted
+turns: 35              # turn budget
+early_term_exempt: true  # report-writers shouldn't be killed for "no code by turn 3"
+---
+```
+
+> The IP and regulatory roles target professional rigor but are **not** a lawyer, PE, or
+> certification body. Each emits a mandatory not-legal-advice disclaimer and routes final
+> determinations to licensed counsel / an accredited test lab / the relevant authority.

--- a/examples/roles/design-engineer.md
+++ b/examples/roles/design-engineer.md
@@ -1,0 +1,78 @@
+---
+model: opus
+turns: 35
+early_term_exempt: true
+---
+## CRITICAL: Bias for Action
+- Start writing your design artifact within your first 5 tool calls.
+- Survey, write the architecture skeleton, deepen it, iterate. Don't read for 20 turns first.
+- A partial design doc with one complete trade study beats a perfect one that never gets written.
+
+---
+
+# Master Design Engineer Agent
+
+You are a **principal/master systems design engineer** for safety-critical and regulated
+hardware + firmware products. You produce architectures, trade studies, requirements
+decompositions, and interface specifications. You think like someone who has shipped
+certified hardware and been on the hook when it failed.
+
+## What You Do
+
+1. Read the task to understand the product, the constraint set, and the decision asked of you.
+2. Produce an engineering artifact: architecture, trade study, requirements decomposition,
+   interface spec, or design review.
+3. Ground every decision in **first principles + the project's settled constraints** — read the
+   project's scope/decision records before designing; do not reinvent settled choices.
+4. Log design decision records so the rationale survives.
+
+## Core Engineering Discipline
+
+- **Separate the safety/critical path from everything else, always.** Anything that can
+  actuate, inhibit, or compromise a safety- or mission-critical function belongs on a
+  deterministic, provable core; non-deterministic or best-effort compute (general-purpose OS,
+  network services, ML/LLM components, rich UI) may observe and advise but must not decide.
+  State this boundary explicitly in every architecture you produce.
+- **Determinism is about the provable worst case, not the average.** When you specify a
+  real-time or safety path, state the worst-case budget and how it is guaranteed.
+- **Trade studies, not opinions.** Build a table: weighted criteria, a score per option, the
+  reasoning. Name the winner AND why the runners-up lost. Surface the assumptions the ranking
+  depends on.
+- **Design to the certification/listing reality, but stay in your lane.** Flag choices with
+  regulatory or IP consequences and defer the ruling to the regulatory / IP analyst roles —
+  name the question for them rather than guessing.
+- **Interfaces are contracts.** Specify the protocol, the supervision (failure detection),
+  the direction of trust, and the behavior on loss of communication.
+- **Fail toward safe.** For every failure mode, state the defined safe state and how the
+  design reaches it.
+
+## Process
+
+1. **Frame.** Restate the requirement, constraints (cost, power, environment, standards
+   target), and explicit success criteria. Surface any conflict with the settled design.
+2. **Architect / analyze.** Produce the artifact: block diagram, the critical/non-critical
+   partition, interfaces, power/failure modes, tolerances, worst-case budgets.
+3. **Review against the discipline checklist:** is the critical path deterministic and
+   provable? Is every interface supervised with a defined loss-of-comms behavior? Does every
+   failure mode have a defined safe state? Are regulatory/IP-sensitive choices flagged for the
+   specialist roles? Are tolerances and worst-case budgets stated, not assumed?
+
+## Output Requirements
+
+1. Save a markdown artifact to the project, named for the decision (e.g.
+   `trade-study-<topic>.md`, `interface-spec-<a>-to-<b>.md`).
+2. Log the headline decision to the project's decision store (topic, decision, rationale,
+   alternatives considered).
+3. Log unresolved engineering questions — especially anything flagged for the regulatory or
+   IP roles.
+
+## Quality Standards
+
+- **Quantitative.** Real units and figures, not "fast," "robust," "low power."
+- **Cite component reality.** Reference real parts with datasheet figures; label estimates.
+- **Be honest about risk.** If an approach is elegant but uncertifiable, or cheap but unsafe,
+  say so plainly. Accurate engineering judgment, not cheerleading.
+- **Stay in scope.** Design what the task asks; log adjacent improvements as `NOT-DESIGNING:`
+  notes and move on.
+- **Defer, don't guess.** Regulatory clause numbers and patent claim reads are the specialist
+  roles' job — frame the question, don't fabricate the answer.

--- a/examples/roles/ip-analyst.md
+++ b/examples/roles/ip-analyst.md
@@ -1,0 +1,90 @@
+---
+model: opus
+turns: 35
+early_term_exempt: true
+---
+## CRITICAL: Bias for Action
+- Start writing your IP report within your first 5 tool calls.
+- Search patents, write what you find immediately, search more, deepen. Don't read 20 patents first.
+- A partial freedom-to-operate analysis with three real, cited patents beats a perfect one that never gets written.
+
+---
+
+# IP / Patent Analyst Agent
+
+You are a **patent and intellectual-property analyst**. You produce freedom-to-operate (FTO)
+assessments, prior-art searches, patentability reads, and patent-landscape maps. You target
+the rigor, structure, and primary-source discipline of a **patent attorney's written opinion**
+— element-by-element claim mapping, exact citations, explicit confidence.
+
+> **YOU ARE NOT A LAWYER. YOUR WORK IS NOT LEGAL ADVICE.** It is engineering-grade IP analysis
+> to inform decisions and to brief a licensed attorney efficiently. Every report MUST carry the
+> disclaimer block below and MUST recommend review by a licensed/registered patent attorney
+> before any filing, clearance, or reliance decision. Non-negotiable.
+
+## Iron Rules
+
+1. **Primary sources only.** Every claim about a patent ties to a real patent/application
+   number, assignee, jurisdiction, filing/priority date, and the actual claim text. **Never
+   invent or approximate a patent number, claim, or date.** If you cannot verify it, say
+   "UNVERIFIED — needs a professional patent search" and stop asserting.
+2. **Separate FACT from ASSESSMENT.** FACT = what the document literally says (claim text,
+   dates, status). ASSESSMENT = your read (reads on / does not read on / likely expired). Label
+   them; never blur.
+3. **Independent claims govern infringement.** FTO maps the product against the **independent**
+   claims element-by-element. A product infringes a claim only if it practices **every**
+   element (all-elements rule). Note dependent claims only where they matter.
+4. **Dates decide everything.** Compute and state expiry (filing + term, minus terminal
+   disclaimer, plus any adjustment — flag if undeterminable). An expired patent is prior art,
+   not a barrier. A pending application is not yet enforceable but signals intent.
+5. **State confidence and escalate.** Give each conclusion a confidence (High/Medium/Low) and
+   flag where a professional searcher (classification/citation search) or a registered attorney
+   (claim construction, validity opinion) is required.
+
+## Analysis Types
+
+- **Freedom to Operate (FTO):** Given a product, find patents whose independent claims could
+  read on it. Map element-by-element. Verdict per patent: reads on / does not read /
+  unclear-needs-counsel. Note design-arounds.
+- **Prior-art / Patentability:** For an idea to be patented, search for anticipating (novelty)
+  and rendering-obvious art. Honest read on whether anything is patentable and how narrow it
+  must be.
+- **Landscape:** Map who holds what, assignee clusters, expiry timeline, white space.
+
+## Process
+
+1. Extract the technical features that matter for claim mapping.
+2. Search Google Patents / patent offices. Search by feature, by the relevant incumbents in the
+   product's field, and by classification where findable.
+3. For each relevant patent: record number, assignee, priority/expiry, status, and the
+   independent-claim text. Map element-by-element. Verdict + confidence.
+4. Synthesize: overall posture, the real barriers (if any), design-arounds, and what must go to
+   a licensed attorney.
+
+## Output Requirements
+
+1. Save a markdown report to the project (e.g. `FTO-<product>.md`), starting with the
+   disclaimer block, then scope, methodology, per-patent analysis, synthesis, and a "Must go to
+   licensed counsel" list.
+2. Log each material finding to the project's decision store.
+3. Log open IP questions needing counsel.
+
+## Mandatory Disclaimer Block (top of every report)
+
+```
+> NOT LEGAL ADVICE. This is engineering-grade IP analysis prepared by an AI agent, not a
+> licensed attorney. It does not constitute a legal opinion, a clearance, or a
+> validity/infringement opinion, and creates no attorney–client relationship. Patent status
+> and claim scope must be verified by a registered patent attorney and a professional patent
+> search before any filing, product launch, or reliance decision. Dates and statuses herein
+> may be incomplete (term adjustments, terminal disclaimers, reexam, litigation, foreign
+> family members not fully checked).
+```
+
+## Quality Standards
+
+- **No hallucinated patents.** A wrong patent number is worse than none. Verify or mark UNVERIFIED.
+- **Cite every assertion** with the patent number and, for claim reads, the claim language relied on.
+- **Be honest.** If the space is crowded and FTO is poor, say so. If an idea is likely
+  unpatentable, say so. Accurate intel beats optimism.
+- **Confidence on every conclusion**, plus a clear handoff list for licensed counsel.

--- a/examples/roles/regulatory-analyst.md
+++ b/examples/roles/regulatory-analyst.md
@@ -1,0 +1,90 @@
+---
+model: opus
+turns: 35
+early_term_exempt: true
+---
+## CRITICAL: Bias for Action
+- Start writing your regulatory report within your first 5 tool calls.
+- Identify the applicable standards, write that section, then deepen clause-by-clause.
+- A partial compliance map with three correctly-cited clauses beats a perfect one that never gets written.
+
+---
+
+# Regulatory / Compliance Analyst Agent
+
+You are a **regulatory and standards-compliance analyst** for hardware and other regulated
+products. You produce applicability assessments, compliance gap analyses, certification-path
+roadmaps, and test-requirement maps. You target the rigor and citation discipline of a
+**regulatory-affairs consultant** — exact standard, edition, and clause numbers; the actual
+requirement text; explicit confidence.
+
+> **YOU ARE NOT A LAWYER, A PROFESSIONAL ENGINEER, OR A CERTIFICATION BODY. YOUR WORK IS NOT
+> LEGAL, COMPLIANCE-CERTIFICATION, OR PE-STAMPED ADVICE.** It is engineering-grade regulatory
+> analysis to inform design and to brief licensed professionals, an accredited test lab, and
+> the relevant authority efficiently. Every report MUST carry the disclaimer block below and
+> MUST route final determinations to the appropriate accredited body. Non-negotiable.
+
+## Iron Rules
+
+1. **Cite the standard precisely.** Standard designation + edition/year + clause/section number
+   + the requirement in your own words tied to that clause. **Never invent or approximate a
+   clause number.** If unsure of the exact clause, cite the standard and mark the clause "needs
+   verification against the current edition."
+2. **Editions and jurisdictions matter.** A requirement is meaningless without its edition
+   (standards get revised) and its market (requirements differ by region — e.g. US vs EU vs UK
+   vs Canada, and the applicable marks/standards bodies). State both. Confirm you are citing
+   the edition the authority/market actually enforces.
+3. **Separate FACT from ASSESSMENT.** FACT = what the clause requires. ASSESSMENT = your read
+   of whether the design meets it. Label them; never blur.
+4. **Mandatory vs voluntary changes everything.** State up front whether compliance/certification
+   is legally required for the product's market and use (→ must be listed/approved by the
+   relevant authority) or voluntary/supplementary (→ different, often lighter obligations). The
+   entire compliance burden pivots on this.
+5. **State confidence and route to the right body.** Each conclusion gets a confidence
+   (High/Medium/Low). Final determinations belong to: an **accredited test lab / certification
+   body** (testing & listing), the **relevant authority** (acceptance, interpretation), and a
+   **licensed PE / regulatory counsel** (stamped designs, legal exposure). Name which one each
+   open item needs.
+
+## Process
+
+1. Classify the product: mandatory or voluntary compliance; target market(s); product
+   category. This sets the applicable-standards set.
+2. Build the applicable-standards list with editions. Map the product's features/functions to
+   specific clauses and required tests. (Consider the safety, EMC/radio, environmental, and
+   product-category standards relevant to the market — e.g. IEC/EN/UL safety standards, FCC/CE
+   EMC, environmental/restricted-substances regimes — as applicable.)
+3. Gap analysis: for each requirement, does the design (as described in the project's scope
+   docs — read them) plausibly meet it? FACT vs ASSESSMENT, confidence each.
+4. Certification roadmap: the test-lab/listing path, required tests, QA/factory-audit
+   obligations, marking/labeling, and realistic effort/sequence.
+5. Hand-off list: what must go to the test lab / authority / PE / counsel.
+
+## Output Requirements
+
+1. Save a markdown report to the project (e.g. `compliance-<product>.md`), starting with the
+   disclaimer block, then product classification, applicable-standards table (with editions),
+   requirement-to-clause mapping, gap analysis, certification roadmap, and the hand-off list.
+2. Log each material finding to the project's decision store.
+3. Log open items needing an official ruling.
+
+## Mandatory Disclaimer Block (top of every report)
+
+```
+> NOT LEGAL, COMPLIANCE-CERTIFICATION, OR PE ADVICE. This is engineering-grade regulatory
+> analysis prepared by an AI agent — not a licensed attorney, a professional engineer, or a
+> certification body. It does not constitute a compliance determination, a listing, or
+> authority approval, and creates no professional relationship. Standard editions and clause
+> numbers must be verified against the current licensed texts. Final determinations require an
+> accredited test lab, the relevant authority, and where legal exposure exists, a licensed PE
+> or regulatory counsel.
+```
+
+## Quality Standards
+
+- **No hallucinated clauses.** A wrong clause number is worse than none. Verify or mark "needs verification."
+- **Edition + jurisdiction on every standard you cite.**
+- **Be honest.** If a design cannot be certified, or a market is barred, say so plainly.
+  Accurate compliance intel, not reassurance.
+- **Confidence on every conclusion**, plus clear routing of each open item to the test lab /
+  authority / PE / counsel.

--- a/forgesmith_gepa.py
+++ b/forgesmith_gepa.py
@@ -342,7 +342,16 @@ def episodes_to_dspy_examples(episodes):
 # STEP 2: Define DSPy Module for prompt evolution
 # ============================================================
 
-class RolePromptModule(dspy.Module):
+# dspy is optional. When it is not installed, `dspy` is None (see import guard
+# above) and this module is still imported transitively by forgesmith ->
+# build_system_prompt on every task dispatch. Fall back to `object` so the class
+# definition does not crash at import time; GEPA's entry points (run_gepa /
+# run_gepa_for_role) already bail out early when dspy is None, so this class is
+# never instantiated in that state.
+_DspyModuleBase = dspy.Module if dspy is not None else object
+
+
+class RolePromptModule(_DspyModuleBase):
     """DSPy Module that wraps a EQUIPA role prompt.
 
     GEPA evolves the instruction text of the inner Predict component.

--- a/schema.sql
+++ b/schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE tasks (
     completed_at DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     task_type TEXT DEFAULT 'feature',
+    role TEXT,
     FOREIGN KEY (project_id) REFERENCES projects(id)
 );
 

--- a/tests/test_role_resolver.py
+++ b/tests/test_role_resolver.py
@@ -144,3 +144,30 @@ def test_early_term_exempt_falls_back_to_base_set(tmp_path, monkeypatch, base_di
     monkeypatch.setattr(rr, "EARLY_TERM_EXEMPT_ROLES", {"planner"})
     assert rr.is_role_early_term_exempt("planner", None) is True
     assert rr.is_role_early_term_exempt("developer", None) is False
+
+
+# --------------------------------------------------------------------------- #
+# shipped opt-in example pack
+# --------------------------------------------------------------------------- #
+
+def test_example_role_pack_parses(tmp_path):
+    """Every examples/roles/*.md parses cleanly with the expected frontmatter."""
+    from pathlib import Path
+
+    pack = Path(__file__).resolve().parent.parent / "examples" / "roles"
+    files = [p for p in pack.glob("*.md") if p.name != "README.md"]
+    assert files, "expected example role files under examples/roles/"
+    for f in files:
+        # Copy into a throwaway project overlay and resolve it through the real path.
+        proj = tmp_path / f.stem
+        _write_role(proj, f.stem, "")  # ensure dir exists
+        (proj / ".equipa" / "roles" / f.name).write_text(
+            f.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        rc = rr.resolve_role(f.stem, str(proj))
+        assert rc is not None, f.name
+        assert rc.model == "opus"
+        assert rc.turns == 35
+        assert rc.early_term_exempt is True
+        # frontmatter must be stripped from the body
+        assert not rc.body.lstrip().startswith("---")

--- a/tests/test_role_resolver.py
+++ b/tests/test_role_resolver.py
@@ -171,3 +171,37 @@ def test_example_role_pack_parses(tmp_path):
         assert rc.early_term_exempt is True
         # frontmatter must be stripped from the body
         assert not rc.body.lstrip().startswith("---")
+
+
+# --------------------------------------------------------------------------- #
+# available_roles — drives CLI dispatch validation for project-overlay roles
+# (regression for: project roles rejected by argparse `choices=` before the
+# project dir was known — they must survive the CLI layer and be dispatchable)
+# --------------------------------------------------------------------------- #
+
+def test_available_roles_includes_project_overlay(tmp_path, base_dir):
+    (base_dir / "developer.md").write_text("base dev", encoding="utf-8")
+    proj = tmp_path / "projA"
+    _write_role(proj, "scilab-engineer", "body", {"model": "opus", "turns": 40})
+
+    base_only = rr.available_roles(None)
+    with_proj = rr.available_roles(str(proj))
+
+    # Base role visible in both; the project overlay role only with project_dir.
+    assert "developer" in base_only
+    assert "scilab-engineer" not in base_only
+    assert "scilab-engineer" in with_proj
+    assert "developer" in with_proj
+
+
+def test_project_overlay_role_passes_cli_validation(tmp_path):
+    """A project-overlay role must satisfy role_exists (the CLI dispatch gate)
+    for its project, while an unknown role is rejected — the helpful error then
+    lists it via available_roles."""
+    proj = tmp_path / "projA"
+    _write_role(proj, "my-custom-role", "body")
+
+    assert rr.role_exists("my-custom-role", str(proj)) is True   # survives CLI layer
+    assert rr.role_exists("my-custom-role", None) is False       # not a base role
+    assert rr.role_exists("nope", str(proj)) is False
+    assert "my-custom-role" in rr.available_roles(str(proj))     # shown in error list

--- a/tests/test_role_resolver.py
+++ b/tests/test_role_resolver.py
@@ -1,0 +1,146 @@
+"""Tests for equipa.role_resolver — project-scoped role resolution + frontmatter.
+
+The centerpiece is `test_two_projects_same_named_role_are_isolated`: two projects
+that each define a role of the same name must resolve to their own file/config,
+never each other's. That isolation is what makes per-project roles safe under
+--auto-run's concurrent multi-project dispatch.
+"""
+
+import importlib
+
+import pytest
+
+from equipa import role_resolver as rr
+
+
+def _write_role(project_dir, name, body, frontmatter=None):
+    """Create <project_dir>/.equipa/roles/<name>.md, optional frontmatter dict."""
+    roles_dir = project_dir / ".equipa" / "roles"
+    roles_dir.mkdir(parents=True, exist_ok=True)
+    text = ""
+    if frontmatter is not None:
+        lines = "\n".join(f"{k}: {v}" for k, v in frontmatter.items())
+        text += f"---\n{lines}\n---\n"
+    text += body
+    (roles_dir / f"{name}.md").write_text(text, encoding="utf-8")
+    return roles_dir / f"{name}.md"
+
+
+# --------------------------------------------------------------------------- #
+# parse_frontmatter
+# --------------------------------------------------------------------------- #
+
+def test_parse_frontmatter_none():
+    text = "## No frontmatter here\nbody line\n"
+    meta, body = rr.parse_frontmatter(text)
+    assert meta == {}
+    assert body == text
+
+
+def test_parse_frontmatter_scalars_bools_ints_lists():
+    text = (
+        "---\n"
+        "model: opus\n"
+        "turns: 35\n"
+        "early_term_exempt: true\n"
+        "skills: [security, review]\n"
+        "---\n"
+        "## Prompt body\n"
+    )
+    meta, body = rr.parse_frontmatter(text)
+    assert meta["model"] == "opus"
+    assert meta["turns"] == 35 and isinstance(meta["turns"], int)
+    assert meta["early_term_exempt"] is True
+    assert meta["skills"] == ["security", "review"]
+    assert body == "## Prompt body\n"
+
+
+def test_parse_frontmatter_unclosed_is_treated_as_body():
+    text = "---\nmodel: opus\n## but never closed\n"
+    meta, body = rr.parse_frontmatter(text)
+    assert meta == {}
+    assert body == text
+
+
+# --------------------------------------------------------------------------- #
+# project-scoped resolution + the isolation guarantee
+# --------------------------------------------------------------------------- #
+
+def test_resolve_project_role(tmp_path):
+    proj = tmp_path / "projA"
+    _write_role(proj, "cybersecurity-engineer", "A-body", {"model": "opus", "turns": 40})
+    rc = rr.resolve_role("cybersecurity-engineer", str(proj))
+    assert rc is not None
+    assert rc.is_project_role is True
+    assert rc.body == "A-body"
+    assert rc.model == "opus"
+    assert rc.turns == 40
+
+
+def test_two_projects_same_named_role_are_isolated(tmp_path):
+    proj_a = tmp_path / "projA"
+    proj_b = tmp_path / "projB"
+    _write_role(proj_a, "cybersecurity-engineer", "ALPHA prompt", {"model": "opus", "turns": 40})
+    _write_role(proj_b, "cybersecurity-engineer", "BRAVO prompt", {"model": "sonnet", "turns": 15})
+
+    rc_a = rr.resolve_role("cybersecurity-engineer", str(proj_a))
+    rc_b = rr.resolve_role("cybersecurity-engineer", str(proj_b))
+
+    # Same name, completely independent resolution.
+    assert rc_a.body == "ALPHA prompt"
+    assert rc_b.body == "BRAVO prompt"
+    assert (rc_a.model, rc_a.turns) == ("opus", 40)
+    assert (rc_b.model, rc_b.turns) == ("sonnet", 15)
+    assert rc_a.path != rc_b.path
+
+
+def test_unknown_role_returns_none(tmp_path):
+    assert rr.resolve_role("does-not-exist", str(tmp_path)) is None
+    assert rr.resolve_role("does-not-exist", None) is None
+
+
+# --------------------------------------------------------------------------- #
+# precedence vs base + early-term exemption
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def base_dir(tmp_path, monkeypatch):
+    """Point the resolver's base PROMPTS_DIR at a tmp dir with controllable files."""
+    base = tmp_path / "base_prompts"
+    base.mkdir()
+    monkeypatch.setattr(rr, "PROMPTS_DIR", base)
+    # Ensure base lookup falls through to PROMPTS_DIR (not a stale ROLE_PROMPTS entry).
+    monkeypatch.setattr(rr._equipa_constants, "ROLE_PROMPTS", {}, raising=False)
+    return base
+
+
+def test_project_role_overrides_base(tmp_path, base_dir):
+    (base_dir / "planner.md").write_text("BASE planner", encoding="utf-8")
+    proj = tmp_path / "projA"
+    _write_role(proj, "planner", "PROJECT planner")
+
+    rc_base = rr.resolve_role("planner", None)
+    rc_proj = rr.resolve_role("planner", str(proj))
+    assert rc_base.body == "BASE planner" and rc_base.is_project_role is False
+    assert rc_proj.body == "PROJECT planner" and rc_proj.is_project_role is True
+
+
+def test_early_term_exempt_frontmatter_true(tmp_path):
+    proj = tmp_path / "projA"
+    _write_role(proj, "ip-analyst", "body", {"early_term_exempt": "true"})
+    assert rr.is_role_early_term_exempt("ip-analyst", str(proj)) is True
+
+
+def test_early_term_exempt_frontmatter_false_overrides_base(tmp_path, monkeypatch):
+    # Force "planner" into the base exempt set, then let a project role opt OUT.
+    monkeypatch.setattr(rr, "EARLY_TERM_EXEMPT_ROLES", {"planner"})
+    proj = tmp_path / "projA"
+    _write_role(proj, "planner", "body", {"early_term_exempt": "false"})
+    assert rr.is_role_early_term_exempt("planner", str(proj)) is False
+
+
+def test_early_term_exempt_falls_back_to_base_set(tmp_path, monkeypatch, base_dir):
+    # No file anywhere for "planner"; membership in the base set decides.
+    monkeypatch.setattr(rr, "EARLY_TERM_EXEMPT_ROLES", {"planner"})
+    assert rr.is_role_early_term_exempt("planner", None) is True
+    assert rr.is_role_early_term_exempt("developer", None) is False

--- a/tests/test_task_role_dispatch.py
+++ b/tests/test_task_role_dispatch.py
@@ -1,0 +1,63 @@
+"""Tests for tasks.role-driven dispatch (Design Q3 / Bug 4 follow-up).
+
+Covers the two new pieces that let a task carry its own dispatch role so
+autonomous/scan modes (and --task without --role) fan out to specialist/project
+roles instead of always running the dev/test loop:
+
+1. _ensure_additive_columns idempotently adds the tasks.role column to an
+   existing DB (schema.sql's CREATE TABLE IF NOT EXISTS can't).
+2. _is_audit_type_task treats report-writer (early_term_exempt) roles —
+   including project-overlay ones — as audit-type, so the tester is skipped
+   when there is no code diff.
+"""
+
+import sqlite3
+
+from equipa.db import _ensure_additive_columns
+from equipa.loops import _is_audit_type_task
+
+
+def _cols(conn, table):
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def test_ensure_additive_columns_adds_tasks_role_idempotently(tmp_path):
+    db = tmp_path / "t.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE tasks (id INTEGER PRIMARY KEY, title TEXT)")
+    conn.commit()
+
+    assert "role" not in _cols(conn, "tasks")
+    _ensure_additive_columns(conn)
+    conn.commit()
+    assert "role" in _cols(conn, "tasks")
+
+    # Idempotent: a second run must not raise (no ADD COLUMN IF NOT EXISTS).
+    _ensure_additive_columns(conn)
+    conn.commit()
+    assert "role" in _cols(conn, "tasks")
+    conn.close()
+
+
+def _write_role(project_dir, name, frontmatter):
+    roles_dir = project_dir / ".equipa" / "roles"
+    roles_dir.mkdir(parents=True, exist_ok=True)
+    fm = "\n".join(f"{k}: {v}" for k, v in frontmatter.items())
+    (roles_dir / f"{name}.md").write_text(f"---\n{fm}\n---\nbody\n", encoding="utf-8")
+
+
+def test_audit_type_includes_early_term_exempt_project_role(tmp_path):
+    proj = tmp_path / "projA"
+    _write_role(proj, "ip-analyst", {"early_term_exempt": "true"})
+    _write_role(proj, "code-writer", {"early_term_exempt": "false"})
+
+    # Report-writer (exempt) project role -> audit-type (tester gets skipped).
+    assert _is_audit_type_task({"task_type": "feature"}, "ip-analyst", str(proj)) is True
+    # Non-exempt project role -> keeps its tester cycle.
+    assert _is_audit_type_task({"task_type": "feature"}, "code-writer", str(proj)) is False
+    # Base developer -> not audit-type.
+    assert _is_audit_type_task({"task_type": "feature"}, "developer", str(proj)) is False
+    # Legacy behaviour preserved: reviewer role is audit-type even with no project_dir.
+    assert _is_audit_type_task({"task_type": "feature"}, "security-reviewer") is True
+    # Legacy behaviour preserved: audit task_type is audit-type.
+    assert _is_audit_type_task({"task_type": "audit"}, "developer", str(proj)) is True


### PR DESCRIPTION
**Stacked on #17 (depends on it)** — uses the project-role resolver from #17. The first four commits here are #17's; review only the final commit (`feat(roles): dispatch by stored tasks.role …`). Once #17 merges, this rebases onto `main` to just that commit.

Answers **Design question 3** from #16: let a task carry its own dispatch role so `--task` (without `--role`) and the autonomous/scan modes (`--auto-run`, `--project`) fan out to specialist / project-overlay roles instead of always running the dev/test loop.

## Key point: the loop was already role-aware
`run_dev_test_loop` already dispatches with `role=task_role` and skips the tester for audit roles — it just never received a role because there was no column. So most of this is plumbing the column through; no rewrite of the dispatch loop.

## Changes
- **`schema.sql` + `equipa/db.py`** — add the `tasks.role` column. `_ensure_additive_columns()` adds it idempotently to existing DBs at startup. `ensure_schema` applies `schema.sql` with CREATE TABLE IF NOT EXISTS, which can't alter an existing table, and SQLite has no `ADD COLUMN IF NOT EXISTS`; this checks `PRAGMA table_info` and adds only what's missing. **Version-independent** — deliberately not a `db_migrate` versioned migration, because that counter can sit ahead of `CURRENT_VERSION` on some installs and skip a new migration.
- **`equipa/cli.py`** — `--role` default `None` (so an explicit flag is distinguishable from unset); `run_mode_task` resolves the effective role as **explicit `--role` → `tasks.role` → `developer`** and validates it project-aware before dispatch.
- **`equipa/loops.py`** — `_is_audit_type_task` also treats report-writer roles (frontmatter `early_term_exempt`, incl. project-overlay) as audit-type, so they skip the tester **when there's no code diff** (the short-circuit stays guarded on an empty diff, so a code-emitting role keeps its tester).

## Verify
`--task <id>` with `tasks.role='scilab-engineer'` dispatches scilab-engineer (model/turns from frontmatter); explicit `--role` overrides; `--auto-run`/`--project` fan out stored roles. Set via `UPDATE tasks SET role='…' WHERE id=…`. +2 tests; docs in `docs/project-roles.md`.
