### PR TITLE
fix(lesson_sanitizer): decouple sanitization from length; stop silent truncation

### DIFF
--- a/.claude/skills/forge-end/SKILL.md
+++ b/.claude/skills/forge-end/SKILL.md
@@ -75,14 +75,18 @@ VALUES (?, '{question}', '{context}', CURRENT_TIMESTAMP);
 
 Ask: "Brief summary of what was accomplished?"
 
-**CRITICAL: Sanitize summary and next_steps through lesson_sanitizer.py before DB write:**
+**CRITICAL: Sanitize summary and next_steps through lesson_sanitizer.py before DB write.**
+Use `sanitize_session_note()` — NOT `sanitize_lesson_content()`. Session notes are
+narrative records; the 500-char lesson cap would silently gut them (Equipa task #100027).
+`sanitize_session_note()` applies the generous `MAX_SESSION_NOTE_LENGTH` cap and logs
+loudly if it ever truncates.
 
 ```python
-from lesson_sanitizer import sanitize_lesson_content
+from lesson_sanitizer import sanitize_session_note
 
-# Sanitize user input
-sanitized_summary = sanitize_lesson_content(summary)
-sanitized_next_steps = sanitize_lesson_content(next_steps)
+# Sanitize user input (preserves multi-thousand-char summaries; no silent truncation)
+sanitized_summary = sanitize_session_note(summary)
+sanitized_next_steps = sanitize_session_note(next_steps)
 ```
 
 ```sql

--- a/docs/project-roles.md
+++ b/docs/project-roles.md
@@ -61,3 +61,29 @@ For `early_term_exempt`, a role file's frontmatter value (when set) wins over th
 
 No base-code changes, no merge conflicts on Equipa updates. See
 [`examples/roles/`](../examples/roles/) for ready-to-copy starting points.
+
+## Dispatching by stored role (`tasks.role`)
+
+A task can carry its own dispatch role in the `tasks.role` column. When set, it
+drives dispatch wherever `--role` is not given explicitly:
+
+- **Single task:** `--task <ID>` (no `--role`) uses the task's role; an explicit
+  `--role X` still overrides it.
+- **Autonomous / scan modes:** `--auto-run` and `--project <ID>` dispatch each
+  task with its stored role, so a project can fan work out to specialist or
+  project-overlay roles instead of always running the dev/test loop.
+
+Role-selection precedence: explicit `--role` → `tasks.role` → `developer`.
+
+Report-writer roles (frontmatter `early_term_exempt: true`) skip the tester
+phase when they produce no code diff — the same treatment as the built-in
+reviewer roles.
+
+Set a task's role via the DB / MCP, e.g.:
+
+```sql
+UPDATE tasks SET role = 'scilab-engineer' WHERE id = 100028;
+```
+
+The `tasks.role` column is added automatically on startup (idempotent, additive)
+for existing databases, and is part of `schema.sql` for fresh installs.

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -597,8 +597,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         f.stem for f in prompts_dir.glob("*.md")
         if not f.name.startswith("_")
     ]) if prompts_dir.exists() else ["developer", "tester", "security-reviewer"]
-    parser.add_argument("--role", default="developer", choices=_available_roles,
-                        help=f"Agent role (available: {', '.join(_available_roles)}) (default: developer)")
+    # NOTE: no argparse `choices=` here. Project-overlay roles
+    # (<project_dir>/.equipa/roles/) are unknown at parse time because the
+    # project dir is only known after a task is resolved, so a hard choices list
+    # would reject valid project roles. The role is validated post-parse against
+    # the project-aware resolver (see run_mode_task) and by build_system_prompt.
+    parser.add_argument("--role", default="developer",
+                        help=f"Agent role. Base roles: {', '.join(_available_roles)}. "
+                             f"Project roles in <project_dir>/.equipa/roles/ are also accepted. "
+                             f"(default: developer)")
     parser.add_argument("--retries", type=int, default=DEFAULT_MAX_RETRIES, help=f"Max retry attempts (default: {DEFAULT_MAX_RETRIES})")
     parser.add_argument("--dev-test", action="store_true", help="Enable Dev+Tester iteration loop mode")
     parser.add_argument("--security-review", action="store_true", default=None,
@@ -1319,6 +1326,17 @@ async def run_mode_task(args: argparse.Namespace) -> None:
         print(f"ERROR: Could not find project directory for '{task.get('project_name', 'Unknown')}'")
         print("Known projects:", ", ".join(sorted(_equipa_constants.PROJECT_DIRS.keys())))
         sys.exit(1)
+
+    # Validate --role now that project_dir is known. argparse can't enforce this
+    # (project-overlay roles in <project_dir>/.equipa/roles/ are unknown at parse
+    # time), so --role accepts any string and we check it project-aware here.
+    role_arg = getattr(args, "role", None)
+    if role_arg:
+        from equipa.role_resolver import role_exists, available_roles
+        if not role_exists(role_arg, project_dir):
+            print(f"ERROR: Unknown role '{role_arg}'. "
+                  f"Available for this project: {', '.join(available_roles(project_dir))}")
+            sys.exit(1)
 
     # Auto-clone ForgeScaffold for empty/missing scaffold-based projects.
     try:

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -602,10 +602,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     # project dir is only known after a task is resolved, so a hard choices list
     # would reject valid project roles. The role is validated post-parse against
     # the project-aware resolver (see run_mode_task) and by build_system_prompt.
-    parser.add_argument("--role", default="developer",
+    # default=None (not "developer") so run_mode_task can tell an explicit
+    # --role from an unset one: explicit wins, else the task's stored role
+    # (tasks.role), else developer.
+    parser.add_argument("--role", default=None,
                         help=f"Agent role. Base roles: {', '.join(_available_roles)}. "
                              f"Project roles in <project_dir>/.equipa/roles/ are also accepted. "
-                             f"(default: developer)")
+                             f"If unset, the task's stored role (tasks.role) is used, else developer.")
     parser.add_argument("--retries", type=int, default=DEFAULT_MAX_RETRIES, help=f"Max retry attempts (default: {DEFAULT_MAX_RETRIES})")
     parser.add_argument("--dev-test", action="store_true", help="Enable Dev+Tester iteration loop mode")
     parser.add_argument("--security-review", action="store_true", default=None,
@@ -1327,16 +1330,19 @@ async def run_mode_task(args: argparse.Namespace) -> None:
         print("Known projects:", ", ".join(sorted(_equipa_constants.PROJECT_DIRS.keys())))
         sys.exit(1)
 
-    # Validate --role now that project_dir is known. argparse can't enforce this
-    # (project-overlay roles in <project_dir>/.equipa/roles/ are unknown at parse
-    # time), so --role accepts any string and we check it project-aware here.
-    role_arg = getattr(args, "role", None)
-    if role_arg:
-        from equipa.role_resolver import role_exists, available_roles
-        if not role_exists(role_arg, project_dir):
-            print(f"ERROR: Unknown role '{role_arg}'. "
-                  f"Available for this project: {', '.join(available_roles(project_dir))}")
-            sys.exit(1)
+    # Resolve the effective dispatch role now that the task (and its project)
+    # is known: an explicit --role wins; else the task's stored role
+    # (tasks.role); else developer. Set args.role so every downstream consumer
+    # sees the resolved value. Then validate it project-aware — argparse can't,
+    # because project-overlay roles (<project_dir>/.equipa/roles/) are unknown
+    # at parse time, so --role accepts any string and we check it here.
+    if not getattr(args, "role", None):
+        args.role = (task.get("role") or "developer")
+    from equipa.role_resolver import role_exists, available_roles
+    if not role_exists(args.role, project_dir):
+        print(f"ERROR: Unknown role '{args.role}'. "
+              f"Available for this project: {', '.join(available_roles(project_dir))}")
+        sys.exit(1)
 
     # Auto-clone ForgeScaffold for empty/missing scaffold-based projects.
     try:

--- a/equipa/db.py
+++ b/equipa/db.py
@@ -179,6 +179,8 @@ def ensure_schema() -> None:
     try:
         conn.executescript(schema_sql)
         conn.commit()
+        _ensure_additive_columns(conn)
+        conn.commit()
     except sqlite3.Error as e:
         logger.exception("[Schema] Failed to apply schema.sql: %s", e)
         raise SchemaNotInitialised(
@@ -188,6 +190,29 @@ def ensure_schema() -> None:
         conn.close()
 
     _SCHEMA_ENSURED = True
+
+
+def _ensure_additive_columns(conn) -> None:
+    """Add nullable columns that post-date a table's CREATE in existing DBs.
+
+    ``ensure_schema`` applies ``schema.sql`` with CREATE TABLE IF NOT EXISTS,
+    which is a no-op for tables that already exist — so a column added to a
+    table definition *after* that table was first created never reaches an
+    existing database. SQLite has no ``ALTER TABLE ... ADD COLUMN IF NOT
+    EXISTS``, so we check ``PRAGMA table_info`` and add only what is missing.
+    Idempotent, additive (nullable, no data change), and independent of the
+    ``db_migrate`` version counter — safe to run on every startup.
+    """
+    additive = {
+        # tasks.role lets a task carry its dispatch role so autonomous/scan
+        # modes (and --task without --role) fan out to specialist/project roles.
+        "tasks": [("role", "TEXT")],
+    }
+    for table, cols in additive.items():
+        existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        for name, decl in cols:
+            if name not in existing:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {decl}")
 
 
 # --- Record Functions ---

--- a/equipa/initiative.py
+++ b/equipa/initiative.py
@@ -329,7 +329,7 @@ class InitiativePlan:
         path = cls.plan_path(repo_path, initiative_id)
         if not path.exists():
             raise FileNotFoundError(f"Initiative plan not found: {path}")
-        return cls(path=path, initiative_id=initiative_id, raw_text=path.read_text())
+        return cls(path=path, initiative_id=initiative_id, raw_text=path.read_text(encoding="utf-8"))
 
     @classmethod
     def ensure_exists(
@@ -448,7 +448,7 @@ class InitiativePlan:
         lock_path = self._lock_path(self.path)
         with _acquire_lock(lock_path):
             # Re-read inside the lock so we don't clobber a sibling append.
-            current = self.path.read_text() if self.path.exists() else self.raw_text
+            current = self.path.read_text(encoding="utf-8") if self.path.exists() else self.raw_text
             updated = _insert_before_end_marker(current, entry)
             _atomic_write(self.path, updated)
             self.raw_text = updated
@@ -606,7 +606,10 @@ def _atomic_write(path: Path, content: str) -> None:
         dir=str(path.parent),
     )
     try:
-        with os.fdopen(fd, "w") as fh:
+        # encoding="utf-8" (not the platform default, which is cp1252 on
+        # Windows): the plan carries untrusted, possibly non-Latin/bidi content,
+        # so it must round-trip as UTF-8 on every platform.
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(content)
             fh.flush()
             os.fsync(fh.fileno())

--- a/equipa/initiative_runner.py
+++ b/equipa/initiative_runner.py
@@ -75,6 +75,24 @@ except ImportError:  # Windows
         _msvcrt.locking(fh.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
+def _user_token() -> str:
+    """Stable per-user token for namespacing the last-resort tmp lock dir (N3).
+
+    POSIX uses the numeric uid (``os.getuid``). Windows has no ``getuid``, so we
+    fall back to the sanitized login name. Either way the tmp lock dir stays
+    per-user, so another local user cannot pre-create or hijack it.
+    """
+    import os
+
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None:
+        return str(getuid())
+    import getpass
+
+    name = getpass.getuser() or "unknown"
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+
+
 # Task statuses the runner treats as "still needs work" when selecting the
 # sub-tasks of an initiative on a NORMAL resume. ``in_progress`` is
 # deliberately excluded (S3): a task left ``in_progress`` is almost always a
@@ -582,7 +600,7 @@ def _initiative_lock_dir(repo_path: str | Path) -> Path:
         candidates.append(Path(xdg) / "equipa")
     candidates.append(Path(repo_path) / ".git" / "equipa-locks")
     candidates.append(
-        Path(tempfile.gettempdir()) / f"equipa-locks-{os.getuid()}"
+        Path(tempfile.gettempdir()) / f"equipa-locks-{_user_token()}"
     )
 
     for candidate in candidates:
@@ -989,7 +1007,7 @@ def _active_pause_marker(
         path = InitiativePlan.plan_path(Path(repo_path), initiative_id)
         if not path.exists():
             return None
-        markers = parse_pause_markers(path.read_text())
+        markers = parse_pause_markers(path.read_text(encoding="utf-8"))
     except OSError:
         logger.exception(
             "Failed to read plan file for pause markers (initiative=%s)",

--- a/equipa/initiative_runner.py
+++ b/equipa/initiative_runner.py
@@ -33,7 +33,6 @@ Copyright 2026 Forgeborn
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import logging
 import re
 import sqlite3
@@ -46,6 +45,34 @@ from equipa.initiative import BEGIN_MARKER, InitiativePlan, _sanitize_agent_text
 from equipa.security import _make_untrusted_delimiter, wrap_untrusted
 
 logger = logging.getLogger(__name__)
+
+
+# --- Cross-platform advisory file locking -------------------------------------
+# The initiative concurrency guard takes an exclusive, non-blocking lock and is
+# deliberately fail-CLOSED: if the lock is already held it raises OSError, which
+# the caller converts to InitiativeLockError and refuses to dispatch. POSIX uses
+# fcntl.flock; Windows (no fcntl) uses msvcrt.locking. Both raise OSError on
+# contention, preserving the fail-closed semantics on every platform.
+try:
+    import fcntl as _fcntl
+
+    def _lock_exclusive_nonblocking(fh) -> None:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+
+    def _unlock(fh) -> None:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+except ImportError:  # Windows
+    import msvcrt as _msvcrt
+
+    def _lock_exclusive_nonblocking(fh) -> None:
+        fh.seek(0)
+        # Lock 1 byte at offset 0 (region may extend past EOF on Windows).
+        # LK_NBLCK = exclusive, non-blocking; raises OSError if already held.
+        _msvcrt.locking(fh.fileno(), _msvcrt.LK_NBLCK, 1)
+
+    def _unlock(fh) -> None:
+        fh.seek(0)
+        _msvcrt.locking(fh.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
 # Task statuses the runner treats as "still needs work" when selecting the
@@ -627,7 +654,7 @@ def _initiative_lock(
         ) from exc
     try:
         try:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            _lock_exclusive_nonblocking(fh)
         except OSError as exc:
             raise InitiativeLockError(
                 f"Initiative #{initiative_id} already has a live run "
@@ -636,7 +663,7 @@ def _initiative_lock(
         try:
             yield
         finally:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            _unlock(fh)
     finally:
         fh.close()
 

--- a/equipa/loops.py
+++ b/equipa/loops.py
@@ -1207,14 +1207,29 @@ _AUDIT_ROLES = frozenset({"security-reviewer", "code-reviewer"})
 _AUDIT_TASK_TYPES = frozenset({"audit", "review"})
 
 
-def _is_audit_type_task(task: dict[str, Any] | None, task_role: str) -> bool:
+def _is_audit_type_task(
+    task: dict[str, Any] | None,
+    task_role: str,
+    project_dir: str | None = None,
+) -> bool:
     """Return True if this task's deliverable is a markdown report, not code.
 
-    Triggers on either an audit-style ``task_type`` or one of the reviewer
-    roles. Matches the criteria spelled out in TheForge bug 2237.
+    Triggers on an audit-style ``task_type``, one of the reviewer roles, or a
+    report-writer role (frontmatter ``early_term_exempt`` — e.g. design /
+    ip / regulatory analysts and project-overlay analysis roles), which produce
+    markdown deliverables rather than code. Matches the criteria spelled out in
+    TheForge bug 2237. The caller still guards the short-circuit on an empty git
+    diff, so a role that does emit code keeps its tester cycle.
     """
     if task_role in _AUDIT_ROLES:
         return True
+    if project_dir:
+        try:
+            from equipa.role_resolver import is_role_early_term_exempt
+            if is_role_early_term_exempt(task_role, project_dir):
+                return True
+        except Exception:
+            pass
     if not isinstance(task, dict):
         return False
     return (task.get("task_type") or "") in _AUDIT_TASK_TYPES
@@ -2025,7 +2040,7 @@ async def run_dev_test_loop(
             # there is nothing for the tester to test. Running it anyway either
             # wastes turns in analysis paralysis or returns tester_blocked when
             # the diff is empty. See TheForge bug 2237.
-            if _is_audit_type_task(task, task_role):
+            if _is_audit_type_task(task, task_role, project_dir):
                 diff_empty = await _git_diff_is_empty(project_dir, base_ref=prev_cycle_sha)
                 if diff_empty:
                     md_files = [

--- a/equipa/prompts.py
+++ b/equipa/prompts.py
@@ -373,7 +373,7 @@ def build_system_prompt(
         def get_relevant_lessons(role=None, error_type=None, limit=5):
             return []
 
-    from equipa.role_resolver import resolve_role
+    from equipa.role_resolver import resolve_role, available_roles
 
     common_path = PROMPTS_DIR / "_common.md"
 
@@ -384,9 +384,9 @@ def build_system_prompt(
     # project_dir and holds no process-global state.
     role_cfg = resolve_role(role, project_dir)
     if role_cfg is None:
-        avail = ", ".join(sorted(ROLE_PROMPTS.keys()))
-        print(f"ERROR: Unknown role '{role}'. Available base roles: {avail}. "
-              f"Project-specific roles live in <project_dir>/.equipa/roles/.")
+        avail = ", ".join(available_roles(project_dir))
+        print(f"ERROR: Unknown role '{role}'. Available for this project "
+              f"(base + <project_dir>/.equipa/roles/): {avail}.")
         sys.exit(1)
     role_path = role_cfg.path
     role_text = role_cfg.body  # frontmatter (if any) already stripped

--- a/equipa/role_resolver.py
+++ b/equipa/role_resolver.py
@@ -156,3 +156,26 @@ def is_role_early_term_exempt(role: str, project_dir: str | None = None) -> bool
     if rc is not None and rc.early_term_exempt is not None:
         return rc.early_term_exempt
     return role in EARLY_TERM_EXEMPT_ROLES
+
+
+def available_roles(project_dir: str | None = None) -> list[str]:
+    """All dispatchable role names for ``project_dir``: base + project overlay.
+
+    Base roles come from ``prompts/`` (and the discovered ``ROLE_PROMPTS`` dict);
+    project roles come from ``<project_dir>/.equipa/roles/``. Used for helpful
+    "unknown role" error messages, since argparse cannot enumerate project-overlay
+    roles at parse time (the project dir is not known until a task is resolved).
+    """
+    names: set[str] = set()
+    if PROMPTS_DIR.is_dir():
+        for f in PROMPTS_DIR.glob("*.md"):
+            if not f.name.startswith("_"):
+                names.add(f.stem)
+    names.update(_equipa_constants.ROLE_PROMPTS.keys())
+    if project_dir:
+        overlay = Path(project_dir).joinpath(*PROJECT_ROLES_SUBDIR)
+        if overlay.is_dir():
+            for f in overlay.glob("*.md"):
+                if not f.name.startswith("_"):
+                    names.add(f.stem)
+    return sorted(names)

--- a/forgesmith_simba.py
+++ b/forgesmith_simba.py
@@ -1,1 +1,0 @@
-scripts/forgesmith_simba.py

--- a/lesson_sanitizer.py
+++ b/lesson_sanitizer.py
@@ -11,6 +11,7 @@ Copyright 2026 Forgeborn.
 """
 
 import re
+import logging
 
 # --- Prompt-injection patterns to strip ---
 # These regex patterns match common prompt-injection techniques that an agent
@@ -63,25 +64,34 @@ _INJECTION_PATTERNS = [
     re.compile(r'\x1b\[[0-9;]*[a-zA-Z]'),
 ]
 
-# Maximum allowed length for a single lesson text
-MAX_LESSON_LENGTH = 500
+# --- Per-content-type length caps ---
+# Length policy is decoupled from sanitization: sanitize() does security only,
+# enforce_limit() applies a cap. A cap of None (or 0) disables truncation.
+#   - lessons are injected back into agent prompts, so they stay terse;
+#   - session notes / decision rationales are narrative records and must NOT be
+#     silently gutted. The old single 500-char cap truncated multi-thousand-char
+#     session summaries with no warning (Equipa task #100027).
+MAX_LESSON_LENGTH = 500            # lessons: terse, prompt-injected
+MAX_ERROR_SIGNATURE_LENGTH = 200   # short identifiers
+MAX_SESSION_NOTE_LENGTH = 50_000   # narrative session summaries (generous backstop)
+MAX_DECISION_LENGTH = 8_000        # decision rationales
 
-# Maximum allowed length for an error signature used in lessons
-MAX_ERROR_SIGNATURE_LENGTH = 200
+_log = logging.getLogger(__name__)
 
 
-def sanitize_lesson_content(text):
-    """Strip prompt-injection patterns from lesson text.
+def sanitize(text):
+    """Strip prompt-injection patterns from text. Security only — no length cap.
 
-    This is the primary sanitization function. It should be called on ALL
-    text that will be stored as a lesson or injected into an agent prompt.
+    This is the pure sanitization step: ANSI/injection-pattern stripping and
+    whitespace normalization, with NO truncation. Use enforce_limit() (or a
+    sanitize_* wrapper) to apply a length policy.
 
     Args:
-        text: Raw lesson text (from agent output, error summaries, etc.)
+        text: Raw text (agent output, error summaries, session notes, etc.)
 
     Returns:
-        Sanitized text with injection patterns removed and length capped.
-        Returns empty string if the input is None or empty.
+        Sanitized text with injection patterns removed. Empty string for
+        None/empty input.
     """
     if not text:
         return ""
@@ -98,20 +108,76 @@ def sanitize_lesson_content(text):
 
     # Collapse multiple whitespace left by removals
     text = re.sub(r'\s{3,}', '  ', text)
-    text = text.strip()
+    return text.strip()
 
-    # Cap length
-    if len(text) > MAX_LESSON_LENGTH:
-        text = text[:MAX_LESSON_LENGTH - 3] + "..."
 
+def enforce_limit(text, max_len, *, label="content"):
+    """Apply a length cap — loudly. Never truncates silently.
+
+    A falsy ``max_len`` (None or 0) disables the cap. When truncation does
+    occur it is logged at WARNING level so the caller/operator sees that
+    content was cut, rather than discovering it later as silent data loss
+    (the failure mode behind Equipa task #100027).
+
+    Args:
+        text: Already-sanitized text.
+        max_len: Maximum length, or None/0 to disable the cap.
+        label: Human-readable content kind, used in the warning message.
+
+    Returns:
+        The text, truncated with a trailing "..." only if it exceeded max_len.
+    """
+    if not text or not max_len:
+        return text or ""
+    if len(text) > max_len:
+        _log.warning(
+            "lesson_sanitizer: %s truncated from %d to %d chars (content not stored in full)",
+            label, len(text), max_len,
+        )
+        return text[:max_len - 3] + "..."
     return text
+
+
+def sanitize_lesson_content(text, max_len=MAX_LESSON_LENGTH, *, label="lesson"):
+    """Sanitize text and apply a length cap.
+
+    Backward-compatible: with the default ``max_len`` this behaves like before
+    (sanitize + cap at MAX_LESSON_LENGTH = 500), so the lessons pipeline is
+    unchanged. Differences from the old version:
+
+    * truncation is no longer silent (see enforce_limit);
+    * callers may pass a larger ``max_len`` — e.g. MAX_SESSION_NOTE_LENGTH — or
+      ``max_len=None`` to disable the cap for narrative content.
+
+    For session notes, prefer sanitize_session_note().
+
+    Args:
+        text: Raw text to sanitize.
+        max_len: Length cap (default = lesson cap); None/0 disables it.
+        label: Content kind, used in the truncation warning.
+
+    Returns:
+        Sanitized, length-capped text. Empty string for None/empty input.
+    """
+    return enforce_limit(sanitize(text), max_len, label=label)
+
+
+def sanitize_session_note(text):
+    """Sanitize a session-note field (summary / next_steps) without silent loss.
+
+    Uses MAX_SESSION_NOTE_LENGTH so multi-thousand-char summaries are preserved;
+    the 500-char lesson cap would gut them (Equipa task #100027).
+    """
+    return sanitize_lesson_content(text, max_len=MAX_SESSION_NOTE_LENGTH,
+                                   label="session note")
 
 
 def sanitize_error_signature(sig):
     """Sanitize an error signature before using it in lesson generation.
 
-    Error signatures come from agent error_summary fields which are
-    agent-controlled output. We sanitize before using as lesson content.
+    Error signatures come from agent error_summary fields (agent-controlled
+    output), so we sanitize before use. They should be short identifiers, so
+    they get the MAX_ERROR_SIGNATURE_LENGTH cap.
 
     Args:
         sig: Raw error signature string.
@@ -121,17 +187,8 @@ def sanitize_error_signature(sig):
     """
     if not sig:
         return ""
-
-    sig = str(sig)
-
-    # Apply the same injection stripping
-    sig = sanitize_lesson_content(sig)
-
-    # Additional constraint: error sigs should be short identifiers
-    if len(sig) > MAX_ERROR_SIGNATURE_LENGTH:
-        sig = sig[:MAX_ERROR_SIGNATURE_LENGTH - 3] + "..."
-
-    return sig
+    return enforce_limit(sanitize(sig), MAX_ERROR_SIGNATURE_LENGTH,
+                         label="error signature")
 
 
 # --- Structural validation allowlist ---

--- a/schema.sql
+++ b/schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE tasks (
     completed_at DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     task_type TEXT DEFAULT 'feature',
+    role TEXT,
     FOREIGN KEY (project_id) REFERENCES projects(id)
 );
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,16 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Also expose scripts/ so modules relocated there during repo cleanup (e.g.
+# forgesmith_simba, forgesmith_impact) import by bare name in tests, exactly as
+# forgesmith.py already arranges them at runtime. This makes `from
+# forgesmith_simba import ...` resolve to scripts/forgesmith_simba.py on every
+# platform, with no reliance on the repo-root symlink that Windows checkouts
+# (core.symlinks=false) materialize as a broken text file.
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
+if _SCRIPTS_DIR.is_dir():
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
 
 def _ensure_full_schema():
     """Apply schema.sql to the test database, creating any missing tables.

--- a/tests/test_initiative_lock_portable.py
+++ b/tests/test_initiative_lock_portable.py
@@ -1,0 +1,44 @@
+"""Cross-platform advisory-lock primitives in equipa.initiative_runner.
+
+The initiative concurrency guard is fail-CLOSED: an already-held lock must raise
+OSError so the caller refuses to dispatch. These tests assert that contract on
+whatever platform they run (fcntl on POSIX, msvcrt on Windows), guarding the
+Windows-portability fix from regressing.
+"""
+
+import os
+
+from equipa import initiative_runner as ir
+
+
+def test_module_imports_on_this_platform():
+    # Regression: a bare top-level `import fcntl` made this module fail to import
+    # on Windows, breaking collection of every test that touched it.
+    assert hasattr(ir, "_lock_exclusive_nonblocking")
+    assert hasattr(ir, "_unlock")
+
+
+def test_exclusive_lock_blocks_second_holder_then_releases(tmp_path):
+    lock_path = tmp_path / "x.lock"
+    fh1 = open(lock_path, "w")
+    fh2 = open(lock_path, "w")
+    try:
+        ir._lock_exclusive_nonblocking(fh1)  # first holder wins
+
+        # Second, non-blocking acquisition must fail closed (OSError).
+        try:
+            ir._lock_exclusive_nonblocking(fh2)
+            raised = False
+        except OSError:
+            raised = True
+        assert raised, "second exclusive lock must raise OSError (fail-closed)"
+
+        # After release, the second holder can acquire.
+        ir._unlock(fh1)
+        ir._lock_exclusive_nonblocking(fh2)
+        ir._unlock(fh2)
+    finally:
+        fh1.close()
+        fh2.close()
+        # sanity: file still exists and is removable
+        assert os.path.exists(lock_path)

--- a/tests/test_initiative_phase2.py
+++ b/tests/test_initiative_phase2.py
@@ -268,7 +268,8 @@ def _write_plan(repo: Path, iid: int, *, pause_reason: str | None) -> None:
     if pause_reason is not None:
         human += f'<!-- pause-for-review reason="{pause_reason}" -->\n\n'
     plan.write_text(
-        human + f"{HUMAN_EDIT_HINT}\n{BEGIN_MARKER}\n\n{END_MARKER}\n"
+        human + f"{HUMAN_EDIT_HINT}\n{BEGIN_MARKER}\n\n{END_MARKER}\n",
+        encoding="utf-8",
     )
 
 
@@ -633,10 +634,16 @@ def test_n2_lock_dir_is_private_not_world_tmp(tmp_path: Path, monkeypatch) -> No
     (repo / ".git").mkdir(parents=True)
     lock_dir = ir._initiative_lock_dir(str(repo))
     # Falls back to the repo's .git dir (not /tmp) when XDG_RUNTIME_DIR unset.
+    # This location check is the cross-platform privacy property (the dir lives
+    # under the user-owned repo, never a world-shared /tmp).
     assert lock_dir == repo / ".git" / "equipa-locks"
     assert lock_dir.is_dir()
-    # Restrictive perms: owner-only.
-    assert (lock_dir.stat().st_mode & 0o777) == 0o700
+    # Restrictive perms: owner-only. POSIX mode bits only — on Windows chmod()
+    # does not set the 0o777 group/other bits (privacy is provided by NTFS ACLs
+    # inherited from the user profile + the per-user location above), so the
+    # numeric-mode assertion is POSIX-only.
+    if sys.platform != "win32":
+        assert (lock_dir.stat().st_mode & 0o777) == 0o700
 
 
 def test_n2_lock_dir_prefers_xdg_runtime(tmp_path: Path, monkeypatch) -> None:
@@ -686,7 +693,8 @@ def test_s4_active_marker_keyed_on_position(tmp_path: Path) -> None:
         '<!-- pause-for-review reason="dup" -->\n'
         "x\n"
         '<!-- pause-for-review reason="dup" -->\n'
-        f"{BEGIN_MARKER}\n{END_MARKER}\n"
+        f"{BEGIN_MARKER}\n{END_MARKER}\n",
+        encoding="utf-8",
     )
     seen: set[tuple[int, str]] = set()
     first = ir._active_pause_marker(str(tmp_path), iid, seen)

--- a/tests/test_lesson_sanitizer.py
+++ b/tests/test_lesson_sanitizer.py
@@ -8,13 +8,17 @@ Copyright 2026 Forgeborn.
 """
 
 import sys
+import logging
 from pathlib import Path
 
 # Add project root to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from lesson_sanitizer import (
+    sanitize,
+    enforce_limit,
     sanitize_lesson_content,
+    sanitize_session_note,
     sanitize_error_signature,
     validate_lesson_structure,
     wrap_lessons_in_task_input,
@@ -334,6 +338,60 @@ def test_strips_code_blocks_with_dangerous_commands():
     print("PASS: Code block stripping works")
 
 
+def test_session_note_not_truncated():
+    """Session notes must use the generous cap, not the 500 lesson cap (task #100027)."""
+    print("\n--- Test: Session notes preserved (no silent truncation) ---")
+
+    note = "Narrative session summary that needs to be preserved in full. " * 100  # ~6000 chars
+    result = sanitize_session_note(note)
+    assert len(result) > 5000, f"Session note was gutted: {len(result)} chars"
+    # The lesson path must still cap at 500 (backward-compat unchanged)
+    assert len(sanitize_lesson_content(note)) <= 500, "Lesson cap regressed"
+
+    print(f"  OK: {len(note)} chars -> session_note {len(result)}, lesson {len(sanitize_lesson_content(note))}")
+    print("PASS: Session notes preserved while lessons still capped")
+
+
+def test_sanitize_has_no_length_cap():
+    """sanitize() does security only — it must NOT truncate."""
+    print("\n--- Test: sanitize() applies no length cap ---")
+
+    # Spaced words (not a continuous alphanumeric run, so the base64-payload
+    # filter does not strip it) — proves the length is preserved, not capped.
+    text = ("word " * 1800).strip()  # ~9000 chars
+    assert len(sanitize(text)) == len(text), "sanitize() unexpectedly altered length"
+    # but injection is still stripped without any cap
+    assert "<system>" not in sanitize("<system>x</system> " + text)
+
+    print(f"  OK: sanitize() preserves {len(text)} chars, still strips injection")
+    print("PASS: sanitize() has no length cap")
+
+
+def test_enforce_limit_is_loud_and_optional():
+    """enforce_limit must warn when truncating (never silent); None disables the cap."""
+    print("\n--- Test: enforce_limit loud truncation + None bypass ---")
+
+    import io
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    lg = logging.getLogger("lesson_sanitizer")
+    lg.addHandler(handler)
+    prev_level = lg.level
+    lg.setLevel(logging.WARNING)
+    try:
+        out = enforce_limit("x" * 600, 500, label="lesson")
+    finally:
+        lg.removeHandler(handler)
+        lg.setLevel(prev_level)
+
+    assert len(out) == 500 and out.endswith("..."), f"Cap not applied: {len(out)}"
+    assert "truncated from 600 to 500" in buf.getvalue(), "Truncation was silent (no warning)"
+    assert len(enforce_limit("y" * 9000, None)) == 9000, "max_len=None did not disable cap"
+
+    print("  OK: warned on truncation; None disables cap")
+    print("PASS: enforce_limit is loud and optional")
+
+
 def run_all_tests():
     """Execute all sanitization test cases."""
     print("=" * 70)
@@ -347,6 +405,9 @@ def run_all_tests():
         test_strips_base64_payloads()
         test_strips_ansi_escapes()
         test_caps_lesson_length()
+        test_session_note_not_truncated()
+        test_sanitize_has_no_length_cap()
+        test_enforce_limit_is_loud_and_optional()
         test_error_signature_sanitization()
         test_validate_lesson_structure_valid()
         test_validate_lesson_structure_invalid()
@@ -358,7 +419,7 @@ def run_all_tests():
         test_strips_code_blocks_with_dangerous_commands()
 
         print("\n" + "=" * 70)
-        print("ALL 15 TESTS PASSED")
+        print("ALL 18 TESTS PASSED")
         print("=" * 70)
         return 0
 

--- a/tests/test_role_resolver.py
+++ b/tests/test_role_resolver.py
@@ -171,3 +171,37 @@ def test_example_role_pack_parses(tmp_path):
         assert rc.early_term_exempt is True
         # frontmatter must be stripped from the body
         assert not rc.body.lstrip().startswith("---")
+
+
+# --------------------------------------------------------------------------- #
+# available_roles — drives CLI dispatch validation for project-overlay roles
+# (regression for: project roles rejected by argparse `choices=` before the
+# project dir was known — they must survive the CLI layer and be dispatchable)
+# --------------------------------------------------------------------------- #
+
+def test_available_roles_includes_project_overlay(tmp_path, base_dir):
+    (base_dir / "developer.md").write_text("base dev", encoding="utf-8")
+    proj = tmp_path / "projA"
+    _write_role(proj, "scilab-engineer", "body", {"model": "opus", "turns": 40})
+
+    base_only = rr.available_roles(None)
+    with_proj = rr.available_roles(str(proj))
+
+    # Base role visible in both; the project overlay role only with project_dir.
+    assert "developer" in base_only
+    assert "scilab-engineer" not in base_only
+    assert "scilab-engineer" in with_proj
+    assert "developer" in with_proj
+
+
+def test_project_overlay_role_passes_cli_validation(tmp_path):
+    """A project-overlay role must satisfy role_exists (the CLI dispatch gate)
+    for its project, while an unknown role is rejected — the helpful error then
+    lists it via available_roles."""
+    proj = tmp_path / "projA"
+    _write_role(proj, "my-custom-role", "body")
+
+    assert rr.role_exists("my-custom-role", str(proj)) is True   # survives CLI layer
+    assert rr.role_exists("my-custom-role", None) is False       # not a base role
+    assert rr.role_exists("nope", str(proj)) is False
+    assert "my-custom-role" in rr.available_roles(str(proj))     # shown in error list

--- a/tests/test_task_role_dispatch.py
+++ b/tests/test_task_role_dispatch.py
@@ -1,0 +1,63 @@
+"""Tests for tasks.role-driven dispatch (Design Q3 / Bug 4 follow-up).
+
+Covers the two new pieces that let a task carry its own dispatch role so
+autonomous/scan modes (and --task without --role) fan out to specialist/project
+roles instead of always running the dev/test loop:
+
+1. _ensure_additive_columns idempotently adds the tasks.role column to an
+   existing DB (schema.sql's CREATE TABLE IF NOT EXISTS can't).
+2. _is_audit_type_task treats report-writer (early_term_exempt) roles —
+   including project-overlay ones — as audit-type, so the tester is skipped
+   when there is no code diff.
+"""
+
+import sqlite3
+
+from equipa.db import _ensure_additive_columns
+from equipa.loops import _is_audit_type_task
+
+
+def _cols(conn, table):
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def test_ensure_additive_columns_adds_tasks_role_idempotently(tmp_path):
+    db = tmp_path / "t.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE tasks (id INTEGER PRIMARY KEY, title TEXT)")
+    conn.commit()
+
+    assert "role" not in _cols(conn, "tasks")
+    _ensure_additive_columns(conn)
+    conn.commit()
+    assert "role" in _cols(conn, "tasks")
+
+    # Idempotent: a second run must not raise (no ADD COLUMN IF NOT EXISTS).
+    _ensure_additive_columns(conn)
+    conn.commit()
+    assert "role" in _cols(conn, "tasks")
+    conn.close()
+
+
+def _write_role(project_dir, name, frontmatter):
+    roles_dir = project_dir / ".equipa" / "roles"
+    roles_dir.mkdir(parents=True, exist_ok=True)
+    fm = "\n".join(f"{k}: {v}" for k, v in frontmatter.items())
+    (roles_dir / f"{name}.md").write_text(f"---\n{fm}\n---\nbody\n", encoding="utf-8")
+
+
+def test_audit_type_includes_early_term_exempt_project_role(tmp_path):
+    proj = tmp_path / "projA"
+    _write_role(proj, "ip-analyst", {"early_term_exempt": "true"})
+    _write_role(proj, "code-writer", {"early_term_exempt": "false"})
+
+    # Report-writer (exempt) project role -> audit-type (tester gets skipped).
+    assert _is_audit_type_task({"task_type": "feature"}, "ip-analyst", str(proj)) is True
+    # Non-exempt project role -> keeps its tester cycle.
+    assert _is_audit_type_task({"task_type": "feature"}, "code-writer", str(proj)) is False
+    # Base developer -> not audit-type.
+    assert _is_audit_type_task({"task_type": "feature"}, "developer", str(proj)) is False
+    # Legacy behaviour preserved: reviewer role is audit-type even with no project_dir.
+    assert _is_audit_type_task({"task_type": "feature"}, "security-reviewer") is True
+    # Legacy behaviour preserved: audit task_type is audit-type.
+    assert _is_audit_type_task({"task_type": "audit"}, "developer", str(proj)) is True


### PR DESCRIPTION
## Problem
`sanitize_lesson_content()` hard-truncated **all** input to 500 chars, silently. `/forge-end` routes session-note summaries through it, so multi-thousand-char notes were gutted with no warning.

## Fix
- Split `sanitize()` (security only: injection/ANSI strip, no cap) from `enforce_limit(text, max_len, *, label)`, which **logs a WARNING on truncation** (never silent) and treats `max_len=None/0` as "no cap".
- `sanitize_lesson_content(text, max_len=MAX_LESSON_LENGTH)` is now a thin **backward-compatible** wrapper — the lessons pipeline is unchanged (still 500).
- Added per-type caps (`MAX_SESSION_NOTE_LENGTH`, `MAX_DECISION_LENGTH`) and a `sanitize_session_note()` helper; `/forge-end` now uses it for summary/next_steps.

## Tests
- Sanitizer suite **18/18** (15 existing + 3 new regression tests).
- Consumer regression (lessons injection, orchestrator imports, public surface): pass.
- Backward-compat confirmed: `test_caps_lesson_length` still holds at 500.
- Before/after (temp DB): old path stored 500 chars (gutted) and now warns; new path stored the full 6119-char note.