### PR TITLE
fix(security): make skill-manifest hashing line-ending independent

### DIFF
--- a/docs/project-roles.md
+++ b/docs/project-roles.md
@@ -61,3 +61,29 @@ For `early_term_exempt`, a role file's frontmatter value (when set) wins over th
 
 No base-code changes, no merge conflicts on Equipa updates. See
 [`examples/roles/`](../examples/roles/) for ready-to-copy starting points.
+
+## Dispatching by stored role (`tasks.role`)
+
+A task can carry its own dispatch role in the `tasks.role` column. When set, it
+drives dispatch wherever `--role` is not given explicitly:
+
+- **Single task:** `--task <ID>` (no `--role`) uses the task's role; an explicit
+  `--role X` still overrides it.
+- **Autonomous / scan modes:** `--auto-run` and `--project <ID>` dispatch each
+  task with its stored role, so a project can fan work out to specialist or
+  project-overlay roles instead of always running the dev/test loop.
+
+Role-selection precedence: explicit `--role` → `tasks.role` → `developer`.
+
+Report-writer roles (frontmatter `early_term_exempt: true`) skip the tester
+phase when they produce no code diff — the same treatment as the built-in
+reviewer roles.
+
+Set a task's role via the DB / MCP, e.g.:
+
+```sql
+UPDATE tasks SET role = 'scilab-engineer' WHERE id = 100028;
+```
+
+The `tasks.role` column is added automatically on startup (idempotent, additive)
+for existing databases, and is part of `schema.sql` for fresh installs.

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -597,8 +597,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         f.stem for f in prompts_dir.glob("*.md")
         if not f.name.startswith("_")
     ]) if prompts_dir.exists() else ["developer", "tester", "security-reviewer"]
-    parser.add_argument("--role", default="developer", choices=_available_roles,
-                        help=f"Agent role (available: {', '.join(_available_roles)}) (default: developer)")
+    # NOTE: no argparse `choices=` here. Project-overlay roles
+    # (<project_dir>/.equipa/roles/) are unknown at parse time because the
+    # project dir is only known after a task is resolved, so a hard choices list
+    # would reject valid project roles. The role is validated post-parse against
+    # the project-aware resolver (see run_mode_task) and by build_system_prompt.
+    parser.add_argument("--role", default="developer",
+                        help=f"Agent role. Base roles: {', '.join(_available_roles)}. "
+                             f"Project roles in <project_dir>/.equipa/roles/ are also accepted. "
+                             f"(default: developer)")
     parser.add_argument("--retries", type=int, default=DEFAULT_MAX_RETRIES, help=f"Max retry attempts (default: {DEFAULT_MAX_RETRIES})")
     parser.add_argument("--dev-test", action="store_true", help="Enable Dev+Tester iteration loop mode")
     parser.add_argument("--security-review", action="store_true", default=None,
@@ -1319,6 +1326,17 @@ async def run_mode_task(args: argparse.Namespace) -> None:
         print(f"ERROR: Could not find project directory for '{task.get('project_name', 'Unknown')}'")
         print("Known projects:", ", ".join(sorted(_equipa_constants.PROJECT_DIRS.keys())))
         sys.exit(1)
+
+    # Validate --role now that project_dir is known. argparse can't enforce this
+    # (project-overlay roles in <project_dir>/.equipa/roles/ are unknown at parse
+    # time), so --role accepts any string and we check it project-aware here.
+    role_arg = getattr(args, "role", None)
+    if role_arg:
+        from equipa.role_resolver import role_exists, available_roles
+        if not role_exists(role_arg, project_dir):
+            print(f"ERROR: Unknown role '{role_arg}'. "
+                  f"Available for this project: {', '.join(available_roles(project_dir))}")
+            sys.exit(1)
 
     # Auto-clone ForgeScaffold for empty/missing scaffold-based projects.
     try:

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -602,10 +602,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     # project dir is only known after a task is resolved, so a hard choices list
     # would reject valid project roles. The role is validated post-parse against
     # the project-aware resolver (see run_mode_task) and by build_system_prompt.
-    parser.add_argument("--role", default="developer",
+    # default=None (not "developer") so run_mode_task can tell an explicit
+    # --role from an unset one: explicit wins, else the task's stored role
+    # (tasks.role), else developer.
+    parser.add_argument("--role", default=None,
                         help=f"Agent role. Base roles: {', '.join(_available_roles)}. "
                              f"Project roles in <project_dir>/.equipa/roles/ are also accepted. "
-                             f"(default: developer)")
+                             f"If unset, the task's stored role (tasks.role) is used, else developer.")
     parser.add_argument("--retries", type=int, default=DEFAULT_MAX_RETRIES, help=f"Max retry attempts (default: {DEFAULT_MAX_RETRIES})")
     parser.add_argument("--dev-test", action="store_true", help="Enable Dev+Tester iteration loop mode")
     parser.add_argument("--security-review", action="store_true", default=None,
@@ -1327,16 +1330,19 @@ async def run_mode_task(args: argparse.Namespace) -> None:
         print("Known projects:", ", ".join(sorted(_equipa_constants.PROJECT_DIRS.keys())))
         sys.exit(1)
 
-    # Validate --role now that project_dir is known. argparse can't enforce this
-    # (project-overlay roles in <project_dir>/.equipa/roles/ are unknown at parse
-    # time), so --role accepts any string and we check it project-aware here.
-    role_arg = getattr(args, "role", None)
-    if role_arg:
-        from equipa.role_resolver import role_exists, available_roles
-        if not role_exists(role_arg, project_dir):
-            print(f"ERROR: Unknown role '{role_arg}'. "
-                  f"Available for this project: {', '.join(available_roles(project_dir))}")
-            sys.exit(1)
+    # Resolve the effective dispatch role now that the task (and its project)
+    # is known: an explicit --role wins; else the task's stored role
+    # (tasks.role); else developer. Set args.role so every downstream consumer
+    # sees the resolved value. Then validate it project-aware — argparse can't,
+    # because project-overlay roles (<project_dir>/.equipa/roles/) are unknown
+    # at parse time, so --role accepts any string and we check it here.
+    if not getattr(args, "role", None):
+        args.role = (task.get("role") or "developer")
+    from equipa.role_resolver import role_exists, available_roles
+    if not role_exists(args.role, project_dir):
+        print(f"ERROR: Unknown role '{args.role}'. "
+              f"Available for this project: {', '.join(available_roles(project_dir))}")
+        sys.exit(1)
 
     # Auto-clone ForgeScaffold for empty/missing scaffold-based projects.
     try:

--- a/equipa/db.py
+++ b/equipa/db.py
@@ -179,6 +179,8 @@ def ensure_schema() -> None:
     try:
         conn.executescript(schema_sql)
         conn.commit()
+        _ensure_additive_columns(conn)
+        conn.commit()
     except sqlite3.Error as e:
         logger.exception("[Schema] Failed to apply schema.sql: %s", e)
         raise SchemaNotInitialised(
@@ -188,6 +190,29 @@ def ensure_schema() -> None:
         conn.close()
 
     _SCHEMA_ENSURED = True
+
+
+def _ensure_additive_columns(conn) -> None:
+    """Add nullable columns that post-date a table's CREATE in existing DBs.
+
+    ``ensure_schema`` applies ``schema.sql`` with CREATE TABLE IF NOT EXISTS,
+    which is a no-op for tables that already exist — so a column added to a
+    table definition *after* that table was first created never reaches an
+    existing database. SQLite has no ``ALTER TABLE ... ADD COLUMN IF NOT
+    EXISTS``, so we check ``PRAGMA table_info`` and add only what is missing.
+    Idempotent, additive (nullable, no data change), and independent of the
+    ``db_migrate`` version counter — safe to run on every startup.
+    """
+    additive = {
+        # tasks.role lets a task carry its dispatch role so autonomous/scan
+        # modes (and --task without --role) fan out to specialist/project roles.
+        "tasks": [("role", "TEXT")],
+    }
+    for table, cols in additive.items():
+        existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        for name, decl in cols:
+            if name not in existing:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {decl}")
 
 
 # --- Record Functions ---

--- a/equipa/initiative.py
+++ b/equipa/initiative.py
@@ -329,7 +329,7 @@ class InitiativePlan:
         path = cls.plan_path(repo_path, initiative_id)
         if not path.exists():
             raise FileNotFoundError(f"Initiative plan not found: {path}")
-        return cls(path=path, initiative_id=initiative_id, raw_text=path.read_text())
+        return cls(path=path, initiative_id=initiative_id, raw_text=path.read_text(encoding="utf-8"))
 
     @classmethod
     def ensure_exists(
@@ -448,7 +448,7 @@ class InitiativePlan:
         lock_path = self._lock_path(self.path)
         with _acquire_lock(lock_path):
             # Re-read inside the lock so we don't clobber a sibling append.
-            current = self.path.read_text() if self.path.exists() else self.raw_text
+            current = self.path.read_text(encoding="utf-8") if self.path.exists() else self.raw_text
             updated = _insert_before_end_marker(current, entry)
             _atomic_write(self.path, updated)
             self.raw_text = updated
@@ -606,7 +606,10 @@ def _atomic_write(path: Path, content: str) -> None:
         dir=str(path.parent),
     )
     try:
-        with os.fdopen(fd, "w") as fh:
+        # encoding="utf-8" (not the platform default, which is cp1252 on
+        # Windows): the plan carries untrusted, possibly non-Latin/bidi content,
+        # so it must round-trip as UTF-8 on every platform.
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(content)
             fh.flush()
             os.fsync(fh.fileno())

--- a/equipa/initiative_runner.py
+++ b/equipa/initiative_runner.py
@@ -75,6 +75,24 @@ except ImportError:  # Windows
         _msvcrt.locking(fh.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
+def _user_token() -> str:
+    """Stable per-user token for namespacing the last-resort tmp lock dir (N3).
+
+    POSIX uses the numeric uid (``os.getuid``). Windows has no ``getuid``, so we
+    fall back to the sanitized login name. Either way the tmp lock dir stays
+    per-user, so another local user cannot pre-create or hijack it.
+    """
+    import os
+
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None:
+        return str(getuid())
+    import getpass
+
+    name = getpass.getuser() or "unknown"
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+
+
 # Task statuses the runner treats as "still needs work" when selecting the
 # sub-tasks of an initiative on a NORMAL resume. ``in_progress`` is
 # deliberately excluded (S3): a task left ``in_progress`` is almost always a
@@ -582,7 +600,7 @@ def _initiative_lock_dir(repo_path: str | Path) -> Path:
         candidates.append(Path(xdg) / "equipa")
     candidates.append(Path(repo_path) / ".git" / "equipa-locks")
     candidates.append(
-        Path(tempfile.gettempdir()) / f"equipa-locks-{os.getuid()}"
+        Path(tempfile.gettempdir()) / f"equipa-locks-{_user_token()}"
     )
 
     for candidate in candidates:
@@ -989,7 +1007,7 @@ def _active_pause_marker(
         path = InitiativePlan.plan_path(Path(repo_path), initiative_id)
         if not path.exists():
             return None
-        markers = parse_pause_markers(path.read_text())
+        markers = parse_pause_markers(path.read_text(encoding="utf-8"))
     except OSError:
         logger.exception(
             "Failed to read plan file for pause markers (initiative=%s)",

--- a/equipa/initiative_runner.py
+++ b/equipa/initiative_runner.py
@@ -33,7 +33,6 @@ Copyright 2026 Forgeborn
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import logging
 import re
 import sqlite3
@@ -46,6 +45,34 @@ from equipa.initiative import BEGIN_MARKER, InitiativePlan, _sanitize_agent_text
 from equipa.security import _make_untrusted_delimiter, wrap_untrusted
 
 logger = logging.getLogger(__name__)
+
+
+# --- Cross-platform advisory file locking -------------------------------------
+# The initiative concurrency guard takes an exclusive, non-blocking lock and is
+# deliberately fail-CLOSED: if the lock is already held it raises OSError, which
+# the caller converts to InitiativeLockError and refuses to dispatch. POSIX uses
+# fcntl.flock; Windows (no fcntl) uses msvcrt.locking. Both raise OSError on
+# contention, preserving the fail-closed semantics on every platform.
+try:
+    import fcntl as _fcntl
+
+    def _lock_exclusive_nonblocking(fh) -> None:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+
+    def _unlock(fh) -> None:
+        _fcntl.flock(fh.fileno(), _fcntl.LOCK_UN)
+except ImportError:  # Windows
+    import msvcrt as _msvcrt
+
+    def _lock_exclusive_nonblocking(fh) -> None:
+        fh.seek(0)
+        # Lock 1 byte at offset 0 (region may extend past EOF on Windows).
+        # LK_NBLCK = exclusive, non-blocking; raises OSError if already held.
+        _msvcrt.locking(fh.fileno(), _msvcrt.LK_NBLCK, 1)
+
+    def _unlock(fh) -> None:
+        fh.seek(0)
+        _msvcrt.locking(fh.fileno(), _msvcrt.LK_UNLCK, 1)
 
 
 # Task statuses the runner treats as "still needs work" when selecting the
@@ -627,7 +654,7 @@ def _initiative_lock(
         ) from exc
     try:
         try:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            _lock_exclusive_nonblocking(fh)
         except OSError as exc:
             raise InitiativeLockError(
                 f"Initiative #{initiative_id} already has a live run "
@@ -636,7 +663,7 @@ def _initiative_lock(
         try:
             yield
         finally:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            _unlock(fh)
     finally:
         fh.close()
 

--- a/equipa/loops.py
+++ b/equipa/loops.py
@@ -1207,14 +1207,29 @@ _AUDIT_ROLES = frozenset({"security-reviewer", "code-reviewer"})
 _AUDIT_TASK_TYPES = frozenset({"audit", "review"})
 
 
-def _is_audit_type_task(task: dict[str, Any] | None, task_role: str) -> bool:
+def _is_audit_type_task(
+    task: dict[str, Any] | None,
+    task_role: str,
+    project_dir: str | None = None,
+) -> bool:
     """Return True if this task's deliverable is a markdown report, not code.
 
-    Triggers on either an audit-style ``task_type`` or one of the reviewer
-    roles. Matches the criteria spelled out in TheForge bug 2237.
+    Triggers on an audit-style ``task_type``, one of the reviewer roles, or a
+    report-writer role (frontmatter ``early_term_exempt`` — e.g. design /
+    ip / regulatory analysts and project-overlay analysis roles), which produce
+    markdown deliverables rather than code. Matches the criteria spelled out in
+    TheForge bug 2237. The caller still guards the short-circuit on an empty git
+    diff, so a role that does emit code keeps its tester cycle.
     """
     if task_role in _AUDIT_ROLES:
         return True
+    if project_dir:
+        try:
+            from equipa.role_resolver import is_role_early_term_exempt
+            if is_role_early_term_exempt(task_role, project_dir):
+                return True
+        except Exception:
+            pass
     if not isinstance(task, dict):
         return False
     return (task.get("task_type") or "") in _AUDIT_TASK_TYPES
@@ -2025,7 +2040,7 @@ async def run_dev_test_loop(
             # there is nothing for the tester to test. Running it anyway either
             # wastes turns in analysis paralysis or returns tester_blocked when
             # the diff is empty. See TheForge bug 2237.
-            if _is_audit_type_task(task, task_role):
+            if _is_audit_type_task(task, task_role, project_dir):
                 diff_empty = await _git_diff_is_empty(project_dir, base_ref=prev_cycle_sha)
                 if diff_empty:
                     md_files = [

--- a/equipa/prompts.py
+++ b/equipa/prompts.py
@@ -373,7 +373,7 @@ def build_system_prompt(
         def get_relevant_lessons(role=None, error_type=None, limit=5):
             return []
 
-    from equipa.role_resolver import resolve_role
+    from equipa.role_resolver import resolve_role, available_roles
 
     common_path = PROMPTS_DIR / "_common.md"
 
@@ -384,9 +384,9 @@ def build_system_prompt(
     # project_dir and holds no process-global state.
     role_cfg = resolve_role(role, project_dir)
     if role_cfg is None:
-        avail = ", ".join(sorted(ROLE_PROMPTS.keys()))
-        print(f"ERROR: Unknown role '{role}'. Available base roles: {avail}. "
-              f"Project-specific roles live in <project_dir>/.equipa/roles/.")
+        avail = ", ".join(available_roles(project_dir))
+        print(f"ERROR: Unknown role '{role}'. Available for this project "
+              f"(base + <project_dir>/.equipa/roles/): {avail}.")
         sys.exit(1)
     role_path = role_cfg.path
     role_text = role_cfg.body  # frontmatter (if any) already stripped

--- a/equipa/role_resolver.py
+++ b/equipa/role_resolver.py
@@ -156,3 +156,26 @@ def is_role_early_term_exempt(role: str, project_dir: str | None = None) -> bool
     if rc is not None and rc.early_term_exempt is not None:
         return rc.early_term_exempt
     return role in EARLY_TERM_EXEMPT_ROLES
+
+
+def available_roles(project_dir: str | None = None) -> list[str]:
+    """All dispatchable role names for ``project_dir``: base + project overlay.
+
+    Base roles come from ``prompts/`` (and the discovered ``ROLE_PROMPTS`` dict);
+    project roles come from ``<project_dir>/.equipa/roles/``. Used for helpful
+    "unknown role" error messages, since argparse cannot enumerate project-overlay
+    roles at parse time (the project dir is not known until a task is resolved).
+    """
+    names: set[str] = set()
+    if PROMPTS_DIR.is_dir():
+        for f in PROMPTS_DIR.glob("*.md"):
+            if not f.name.startswith("_"):
+                names.add(f.stem)
+    names.update(_equipa_constants.ROLE_PROMPTS.keys())
+    if project_dir:
+        overlay = Path(project_dir).joinpath(*PROJECT_ROLES_SUBDIR)
+        if overlay.is_dir():
+            for f in overlay.glob("*.md"):
+                if not f.name.startswith("_"):
+                    names.add(f.stem)
+    return sorted(names)

--- a/equipa/security.py
+++ b/equipa/security.py
@@ -30,6 +30,22 @@ def wrap_untrusted(content: str, delimiter: str) -> str:
     return f"<<<{delimiter}>>>\n{content}\n<<<END_{delimiter}>>>"
 
 
+def _hash_md_bytes(data: bytes) -> str:
+    """SHA-256 of *data* with line endings normalized to LF.
+
+    The manifest pins LF-content hashes (the .md files are stored LF in git).
+    Hashing raw bytes makes verification line-ending-sensitive: on a checkout
+    with ``git autocrlf=true`` the working-tree files are CRLF, so raw-byte
+    hashes mismatch the LF manifest on *every* file — verify_skill_integrity
+    fails on Windows while passing on Linux/CI. Normalizing CRLF (and lone CR)
+    to LF before hashing makes verification identical on every platform and git
+    config, and leaves the existing LF manifest valid (LF content is unchanged
+    by normalization, so its hashes don't move).
+    """
+    normalized = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return hashlib.sha256(normalized).hexdigest()
+
+
 def generate_skill_manifest() -> dict[str, str]:
     """Scan all prompt and skill .md files and return a dict of {relative_path: sha256_hex}.
 
@@ -48,7 +64,7 @@ def generate_skill_manifest() -> dict[str, str]:
             # startswith("prompts/") checks and verify_skill_integrity's
             # cross-platform key matching.
             rel_path = md_file.relative_to(base_dir).as_posix()
-            file_hash = hashlib.sha256(md_file.read_bytes()).hexdigest()
+            file_hash = _hash_md_bytes(md_file.read_bytes())
             manifest[rel_path] = file_hash
 
     return manifest
@@ -101,7 +117,7 @@ def verify_skill_integrity() -> bool:
         if not file_path.exists():
             missing.append(rel_path)
             continue
-        actual_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+        actual_hash = _hash_md_bytes(file_path.read_bytes())
         if actual_hash != expected_hash:
             mismatches.append(rel_path)
 

--- a/equipa/security.py
+++ b/equipa/security.py
@@ -43,7 +43,11 @@ def generate_skill_manifest() -> dict[str, str]:
         if not search_dir.is_dir():
             continue
         for md_file in sorted(search_dir.rglob("*.md")):
-            rel_path = str(md_file.relative_to(base_dir))
+            # Use POSIX separators so the manifest is portable across OSes —
+            # str() would emit backslashes on Windows, breaking both the
+            # startswith("prompts/") checks and verify_skill_integrity's
+            # cross-platform key matching.
+            rel_path = md_file.relative_to(base_dir).as_posix()
             file_hash = hashlib.sha256(md_file.read_bytes()).hexdigest()
             manifest[rel_path] = file_hash
 

--- a/forgesmith_simba.py
+++ b/forgesmith_simba.py
@@ -1,1 +1,0 @@
-scripts/forgesmith_simba.py

--- a/schema.sql
+++ b/schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE tasks (
     completed_at DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     task_type TEXT DEFAULT 'feature',
+    role TEXT,
     FOREIGN KEY (project_id) REFERENCES projects(id)
 );
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,16 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# Also expose scripts/ so modules relocated there during repo cleanup (e.g.
+# forgesmith_simba, forgesmith_impact) import by bare name in tests, exactly as
+# forgesmith.py already arranges them at runtime. This makes `from
+# forgesmith_simba import ...` resolve to scripts/forgesmith_simba.py on every
+# platform, with no reliance on the repo-root symlink that Windows checkouts
+# (core.symlinks=false) materialize as a broken text file.
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
+if _SCRIPTS_DIR.is_dir():
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
 
 def _ensure_full_schema():
     """Apply schema.sql to the test database, creating any missing tables.

--- a/tests/test_initiative_lock_portable.py
+++ b/tests/test_initiative_lock_portable.py
@@ -1,0 +1,44 @@
+"""Cross-platform advisory-lock primitives in equipa.initiative_runner.
+
+The initiative concurrency guard is fail-CLOSED: an already-held lock must raise
+OSError so the caller refuses to dispatch. These tests assert that contract on
+whatever platform they run (fcntl on POSIX, msvcrt on Windows), guarding the
+Windows-portability fix from regressing.
+"""
+
+import os
+
+from equipa import initiative_runner as ir
+
+
+def test_module_imports_on_this_platform():
+    # Regression: a bare top-level `import fcntl` made this module fail to import
+    # on Windows, breaking collection of every test that touched it.
+    assert hasattr(ir, "_lock_exclusive_nonblocking")
+    assert hasattr(ir, "_unlock")
+
+
+def test_exclusive_lock_blocks_second_holder_then_releases(tmp_path):
+    lock_path = tmp_path / "x.lock"
+    fh1 = open(lock_path, "w")
+    fh2 = open(lock_path, "w")
+    try:
+        ir._lock_exclusive_nonblocking(fh1)  # first holder wins
+
+        # Second, non-blocking acquisition must fail closed (OSError).
+        try:
+            ir._lock_exclusive_nonblocking(fh2)
+            raised = False
+        except OSError:
+            raised = True
+        assert raised, "second exclusive lock must raise OSError (fail-closed)"
+
+        # After release, the second holder can acquire.
+        ir._unlock(fh1)
+        ir._lock_exclusive_nonblocking(fh2)
+        ir._unlock(fh2)
+    finally:
+        fh1.close()
+        fh2.close()
+        # sanity: file still exists and is removable
+        assert os.path.exists(lock_path)

--- a/tests/test_initiative_phase2.py
+++ b/tests/test_initiative_phase2.py
@@ -268,7 +268,8 @@ def _write_plan(repo: Path, iid: int, *, pause_reason: str | None) -> None:
     if pause_reason is not None:
         human += f'<!-- pause-for-review reason="{pause_reason}" -->\n\n'
     plan.write_text(
-        human + f"{HUMAN_EDIT_HINT}\n{BEGIN_MARKER}\n\n{END_MARKER}\n"
+        human + f"{HUMAN_EDIT_HINT}\n{BEGIN_MARKER}\n\n{END_MARKER}\n",
+        encoding="utf-8",
     )
 
 
@@ -633,10 +634,16 @@ def test_n2_lock_dir_is_private_not_world_tmp(tmp_path: Path, monkeypatch) -> No
     (repo / ".git").mkdir(parents=True)
     lock_dir = ir._initiative_lock_dir(str(repo))
     # Falls back to the repo's .git dir (not /tmp) when XDG_RUNTIME_DIR unset.
+    # This location check is the cross-platform privacy property (the dir lives
+    # under the user-owned repo, never a world-shared /tmp).
     assert lock_dir == repo / ".git" / "equipa-locks"
     assert lock_dir.is_dir()
-    # Restrictive perms: owner-only.
-    assert (lock_dir.stat().st_mode & 0o777) == 0o700
+    # Restrictive perms: owner-only. POSIX mode bits only — on Windows chmod()
+    # does not set the 0o777 group/other bits (privacy is provided by NTFS ACLs
+    # inherited from the user profile + the per-user location above), so the
+    # numeric-mode assertion is POSIX-only.
+    if sys.platform != "win32":
+        assert (lock_dir.stat().st_mode & 0o777) == 0o700
 
 
 def test_n2_lock_dir_prefers_xdg_runtime(tmp_path: Path, monkeypatch) -> None:
@@ -686,7 +693,8 @@ def test_s4_active_marker_keyed_on_position(tmp_path: Path) -> None:
         '<!-- pause-for-review reason="dup" -->\n'
         "x\n"
         '<!-- pause-for-review reason="dup" -->\n'
-        f"{BEGIN_MARKER}\n{END_MARKER}\n"
+        f"{BEGIN_MARKER}\n{END_MARKER}\n",
+        encoding="utf-8",
     )
     seen: set[tuple[int, str]] = set()
     first = ir._active_pause_marker(str(tmp_path), iid, seen)

--- a/tests/test_role_resolver.py
+++ b/tests/test_role_resolver.py
@@ -171,3 +171,37 @@ def test_example_role_pack_parses(tmp_path):
         assert rc.early_term_exempt is True
         # frontmatter must be stripped from the body
         assert not rc.body.lstrip().startswith("---")
+
+
+# --------------------------------------------------------------------------- #
+# available_roles — drives CLI dispatch validation for project-overlay roles
+# (regression for: project roles rejected by argparse `choices=` before the
+# project dir was known — they must survive the CLI layer and be dispatchable)
+# --------------------------------------------------------------------------- #
+
+def test_available_roles_includes_project_overlay(tmp_path, base_dir):
+    (base_dir / "developer.md").write_text("base dev", encoding="utf-8")
+    proj = tmp_path / "projA"
+    _write_role(proj, "scilab-engineer", "body", {"model": "opus", "turns": 40})
+
+    base_only = rr.available_roles(None)
+    with_proj = rr.available_roles(str(proj))
+
+    # Base role visible in both; the project overlay role only with project_dir.
+    assert "developer" in base_only
+    assert "scilab-engineer" not in base_only
+    assert "scilab-engineer" in with_proj
+    assert "developer" in with_proj
+
+
+def test_project_overlay_role_passes_cli_validation(tmp_path):
+    """A project-overlay role must satisfy role_exists (the CLI dispatch gate)
+    for its project, while an unknown role is rejected — the helpful error then
+    lists it via available_roles."""
+    proj = tmp_path / "projA"
+    _write_role(proj, "my-custom-role", "body")
+
+    assert rr.role_exists("my-custom-role", str(proj)) is True   # survives CLI layer
+    assert rr.role_exists("my-custom-role", None) is False       # not a base role
+    assert rr.role_exists("nope", str(proj)) is False
+    assert "my-custom-role" in rr.available_roles(str(proj))     # shown in error list

--- a/tests/test_skill_hash_line_endings.py
+++ b/tests/test_skill_hash_line_endings.py
@@ -1,0 +1,37 @@
+"""Regression: skill-manifest hashing must be line-ending independent.
+
+`tasks`-style integrity manifests pin LF-content hashes (the .md files are
+stored LF in git). The hashing used raw `read_bytes()`, so on a checkout with
+`git autocrlf=true` the working-tree files are CRLF and every file's hash
+mismatched the LF manifest — `verify_skill_integrity()` failed on Windows while
+passing on Linux/CI. `_hash_md_bytes` normalizes CRLF/CR -> LF before hashing.
+
+These pin that the normalization (a) makes CRLF and LF content hash identically
+and (b) leaves an LF file's hash exactly where it was, so the existing committed
+LF manifest stays valid.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from equipa.security import _hash_md_bytes
+
+
+def test_crlf_and_lf_hash_identically() -> None:
+    lf = b"# Title\n\nbody line one\nbody line two\n"
+    crlf = lf.replace(b"\n", b"\r\n")
+    cr = lf.replace(b"\n", b"\r")  # classic-Mac lone CR
+    assert _hash_md_bytes(crlf) == _hash_md_bytes(lf)
+    assert _hash_md_bytes(cr) == _hash_md_bytes(lf)
+
+
+def test_lf_hash_is_unchanged_from_raw_sha256() -> None:
+    """An LF file's normalized hash equals its plain sha256, so the existing
+    LF-content manifest does not need regenerating."""
+    lf = b"line a\nline b\n"
+    assert _hash_md_bytes(lf) == hashlib.sha256(lf).hexdigest()
+
+
+def test_no_trailing_newline_is_stable() -> None:
+    assert _hash_md_bytes(b"no newline") == hashlib.sha256(b"no newline").hexdigest()

--- a/tests/test_skill_integrity.py
+++ b/tests/test_skill_integrity.py
@@ -59,13 +59,18 @@ def test_generate_manifest_includes_prompts_and_skills():
 
 
 def test_generate_manifest_hash_matches_file_content():
-    """Spot-check: the hash for a known file should match its actual SHA-256."""
+    """Spot-check: the manifest hash for a known file matches its SHA-256 over
+    LF-normalized content. Hashing is line-ending independent (see
+    equipa.security._hash_md_bytes), so the expected value is computed over
+    CRLF/CR -> LF normalized bytes — otherwise this would fail on a checkout
+    with git autocrlf=true (CRLF working tree vs LF manifest)."""
     manifest = generate_skill_manifest()
     # Pick the first file and verify
     rel_path = next(iter(manifest))
     expected_hash = manifest[rel_path]
     file_path = REPO_ROOT / rel_path
-    actual_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    normalized = file_path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    actual_hash = hashlib.sha256(normalized).hexdigest()
     assert actual_hash == expected_hash, (
         f"Hash mismatch for {rel_path}: expected {expected_hash}, got {actual_hash}"
     )

--- a/tests/test_task_role_dispatch.py
+++ b/tests/test_task_role_dispatch.py
@@ -1,0 +1,63 @@
+"""Tests for tasks.role-driven dispatch (Design Q3 / Bug 4 follow-up).
+
+Covers the two new pieces that let a task carry its own dispatch role so
+autonomous/scan modes (and --task without --role) fan out to specialist/project
+roles instead of always running the dev/test loop:
+
+1. _ensure_additive_columns idempotently adds the tasks.role column to an
+   existing DB (schema.sql's CREATE TABLE IF NOT EXISTS can't).
+2. _is_audit_type_task treats report-writer (early_term_exempt) roles —
+   including project-overlay ones — as audit-type, so the tester is skipped
+   when there is no code diff.
+"""
+
+import sqlite3
+
+from equipa.db import _ensure_additive_columns
+from equipa.loops import _is_audit_type_task
+
+
+def _cols(conn, table):
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def test_ensure_additive_columns_adds_tasks_role_idempotently(tmp_path):
+    db = tmp_path / "t.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE tasks (id INTEGER PRIMARY KEY, title TEXT)")
+    conn.commit()
+
+    assert "role" not in _cols(conn, "tasks")
+    _ensure_additive_columns(conn)
+    conn.commit()
+    assert "role" in _cols(conn, "tasks")
+
+    # Idempotent: a second run must not raise (no ADD COLUMN IF NOT EXISTS).
+    _ensure_additive_columns(conn)
+    conn.commit()
+    assert "role" in _cols(conn, "tasks")
+    conn.close()
+
+
+def _write_role(project_dir, name, frontmatter):
+    roles_dir = project_dir / ".equipa" / "roles"
+    roles_dir.mkdir(parents=True, exist_ok=True)
+    fm = "\n".join(f"{k}: {v}" for k, v in frontmatter.items())
+    (roles_dir / f"{name}.md").write_text(f"---\n{fm}\n---\nbody\n", encoding="utf-8")
+
+
+def test_audit_type_includes_early_term_exempt_project_role(tmp_path):
+    proj = tmp_path / "projA"
+    _write_role(proj, "ip-analyst", {"early_term_exempt": "true"})
+    _write_role(proj, "code-writer", {"early_term_exempt": "false"})
+
+    # Report-writer (exempt) project role -> audit-type (tester gets skipped).
+    assert _is_audit_type_task({"task_type": "feature"}, "ip-analyst", str(proj)) is True
+    # Non-exempt project role -> keeps its tester cycle.
+    assert _is_audit_type_task({"task_type": "feature"}, "code-writer", str(proj)) is False
+    # Base developer -> not audit-type.
+    assert _is_audit_type_task({"task_type": "feature"}, "developer", str(proj)) is False
+    # Legacy behaviour preserved: reviewer role is audit-type even with no project_dir.
+    assert _is_audit_type_task({"task_type": "feature"}, "security-reviewer") is True
+    # Legacy behaviour preserved: audit task_type is audit-type.
+    assert _is_audit_type_task({"task_type": "audit"}, "developer", str(proj)) is True


### PR DESCRIPTION
## Make skill-manifest hashing line-ending independent

`verify_skill_integrity()` (and `generate_skill_manifest()`) hashed raw
`read_bytes()`, making integrity verification **line-ending-sensitive**. The
manifest pins **LF-content** hashes (the `.md` files are stored LF in git), but
on a checkout with `git autocrlf=true` the working-tree files are **CRLF** — so
every file's hash mismatched the manifest and `verify_skill_integrity()`
**failed on Windows** while passing on Linux/CI.

### Fix
Normalize CRLF/CR → LF before hashing, via a small `_hash_md_bytes` helper used
at both hash sites. Verification is now identical on every platform and git
config. **No manifest regeneration needed:** LF content is unchanged by
normalization, so the existing committed LF manifest's hashes don't move — it
stays valid everywhere.

Verified on a Windows CRLF checkout: `verify_skill_integrity()` now returns
`True` against the unchanged committed manifest (it returned `False` before;
the on-disk CRLF `prompts/_common.md` now normalizes to the manifest's LF hash
`4efe8fa…`).

### Tests
- New `tests/test_skill_hash_line_endings.py`: CRLF == LF == lone-CR hash
  identically; an LF file's normalized hash equals its plain `sha256` (so the
  LF manifest needs no regen).
- `test_generate_manifest_hash_matches_file_content` updated to the normalized
  contract — it previously recomputed via raw bytes and would fail under
  `autocrlf=true`. Full `test_skill_integrity.py` + new file: **14 passed**.

### Background
This is the root-cause fix behind a churn problem that a discarded local commit
tried to "solve" the wrong way — by committing a **CRLF**-hashed manifest, which
would have broken verification on every LF system. The correct answer is
normalize-in-code (here) plus test isolation (#24), not pinning a
platform-specific manifest.

### Stacking
Stacked on #21 (`fix/skill-manifest-windows-paths`) — pairs with that PR's
POSIX-key fix to complete cross-platform manifest integrity (keys *and* values).
Independent of #24; both touch `test_skill_integrity.py` in non-overlapping
regions. Against `main` the diff narrows to this commit once #21 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
