### PR TITLE
chore: add .gitattributes to normalize text files to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Normalize all text files to LF in the repo AND the working tree, regardless of
+# each contributor's local core.autocrlf (e.g. Git-for-Windows defaults it to
+# true). This keeps byte-level tooling stable cross-platform — notably the
+# skill-manifest hashing in equipa/security.py, which on a Windows autocrlf
+# checkout would otherwise read CRLF working-tree bytes and mismatch the
+# LF-content manifest on every file.
+* text=auto eol=lf
+
+# Shell / bats scripts must stay LF to run.
+*.sh   text eol=lf
+*.bats text eol=lf
+
+# Known binaries: never normalize. Most aren't tracked today, but this protects
+# them if added later (DB snapshots, audio, fonts, images).
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.wav    binary
+*.mp3    binary
+*.db     binary
+*.sqlite binary
+*.ttf    binary
+*.otf    binary
+*.woff   binary
+*.woff2  binary
+*.zip    binary
+*.pdf    binary


### PR DESCRIPTION
## Add `.gitattributes` — normalize text to LF

Pins all text files to **LF** in both the repo and the working tree, independent of each contributor's local `core.autocrlf` (Git-for-Windows defaults it to `true`, which is what produced the CRLF-vs-LF skill-manifest hash mismatch fixed in code by #25).

### Why it's safe / quick
- The index is **already clean LF** (544 tracked text files, none committed as CRLF), so `git add --renormalize .` produces **no file churn** — this PR is the single new file, no history rewrite.
- Effect going forward: Windows working-tree files check out as LF, and a contributor can no longer accidentally commit CRLF.

### Relationship to #25
Complementary, not redundant. #25 makes the manifest **hashing** line-ending independent (fixes the actual integrity bug in code). This keeps the **working tree** LF so even raw byte-level tooling/comparisons stay stable cross-platform. Independent of the #17–#21 stack — based directly on `main`.

### Details
- `* text=auto eol=lf` for all text.
- `*.sh` / `*.bats` explicitly LF (must be, to run).
- Defensive `binary` rules for image/audio/db/font/archive types so they're never normalized if added later. No `.bat`/`.cmd` are tracked, so no CRLF exceptions are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)