### PR TITLE
feat(mcp): sanitizing session-note & lesson write-tools (enforce sanitization at the boundary)

### DIFF
--- a/equipa/MODULE_DEPENDENCY_REPORT.md
+++ b/equipa/MODULE_DEPENDENCY_REPORT.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-The `equipa/` package contains **52 Python modules** totaling **31,047 lines** of code across **11 dependency layers** (L0–L10). 27 module(s) use late (deferred) imports to break circular dependencies; there are no top-level circular imports.
+The `equipa/` package contains **52 Python modules** totaling **31,502 lines** of code across **11 dependency layers** (L0–L10). 28 module(s) use late (deferred) imports to break circular dependencies; there are no top-level circular imports.
 
 ## Module Dependency Table
 
@@ -55,7 +55,7 @@ The `equipa/` package contains **52 Python modules** totaling **31,047 lines** o
 | `sessions.py` | 335 | L2 | `checkpoints.py`, `db.py` | `agent_runner.py` | 7 |
 | `tasks.py` | 335 | L2 | `constants.py`, `db.py` | — | 8 |
 | `templates.py` | 943 | L2 | `db.py` | `constants.py`, `embeddings.py` | 8 |
-| `mcp_server.py` | 888 | L3 | `constants.py`, `tasks.py` | — | 12 |
+| `mcp_server.py` | 1315 | L3 | `constants.py`, `tasks.py` | — | 20 |
 | `prompts.py` | 799 | L3 | `config.py`, `constants.py`, `lessons.py`, `parsing.py`, `security.py` | `db.py`, `git_ops.py`, `graph.py`, `initiative.py`, `role_resolver.py` | 8 |
 | `reflexion.py` | 143 | L3 | `db.py`, `lessons.py`, `output.py`, `parsing.py` | `agent_runner.py` | 4 |
 | `agent_runner.py` | 1952 | L4 | `abort_controller.py`, `bash_security.py`, `checkpoints.py`, `config.py`, `constants.py`, `db.py`, `monitoring.py`, `output.py`, `parsing.py`, `prompts.py`, `security.py`, `tasks.py` | `cli.py`, `git_ops.py`, `rlm_decompose.py`, `role_resolver.py` | 21 |
@@ -63,11 +63,11 @@ The `equipa/` package contains **52 Python modules** totaling **31,047 lines** o
 | `loops.py` | 2269 | L6 | `agent_runner.py`, `checkpoints.py`, `classifier.py`, `config.py`, `constants.py`, `db.py`, `git_ops.py`, `hooks/__init__.py`, `messages.py`, `monitoring.py`, `output.py`, `parsing.py`, `preflight.py`, `prompts.py`, `roles.py`, `sessions.py`, `tasks.py` | `role_resolver.py` | 11 |
 | `manager.py` | 312 | L7 | `agent_runner.py`, `constants.py`, `db.py`, `loops.py`, `output.py`, `prompts.py`, `roles.py`, `tasks.py` | — | 5 |
 | `dispatch.py` | 2520 | L8 | `config.py`, `constants.py`, `db.py`, `git_ops.py`, `hooks/__init__.py`, `lessons.py`, `loops.py`, `manager.py`, `output.py`, `parsing.py`, `prompts.py`, `reflexion.py`, `roles.py`, `routing.py`, `security_gate.py`, `single_agent_guard.py`, `tasks.py` | `flows.py`, `initiative.py`, `scaffold.py` | 15 |
-| `cli.py` | 2074 | L9 | `agent_runner.py`, `checkpoints.py`, `config.py`, `constants.py`, `db.py`, `dispatch.py`, `git_ops.py`, `hooks/__init__.py`, `lessons.py`, `loops.py`, `manager.py`, `mcp_server.py`, `monitoring.py`, `output.py`, `parsing.py`, `plugins.py`, `prompts.py`, `reflexion.py`, `roles.py`, `routing.py`, `security.py`, `security_gate.py`, `tasks.py`, `templates.py` | `config_versions.py`, `initiative_runner.py`, `role_resolver.py`, `scaffold.py`, `single_agent_guard.py` | 21 |
-| `__init__.py` | 58 | L10 | `cli.py`, `dispatch.py`, `loops.py`, `manager.py`, `mcp_server.py`, `monitoring.py`, `prompts.py` | — | 14 |
+| `cli.py` | 2082 | L9 | `agent_runner.py`, `checkpoints.py`, `config.py`, `constants.py`, `db.py`, `dispatch.py`, `git_ops.py`, `hooks/__init__.py`, `lessons.py`, `loops.py`, `manager.py`, `monitoring.py`, `output.py`, `parsing.py`, `plugins.py`, `prompts.py`, `reflexion.py`, `roles.py`, `routing.py`, `security.py`, `security_gate.py`, `tasks.py`, `templates.py` | `config_versions.py`, `initiative_runner.py`, `mcp_server.py`, `role_resolver.py`, `scaffold.py`, `single_agent_guard.py` | 21 |
+| `__init__.py` | 78 | L10 | `cli.py`, `dispatch.py`, `loops.py`, `manager.py`, `monitoring.py`, `prompts.py` | `mcp_server.py` | 14 |
 | `__main__.py` | 16 | L10 | `cli.py` | — | 0 |
 
-**Total:** 31,047 lines | 561 public exports
+**Total:** 31,502 lines | 569 public exports
 
 ## Modules by Layer
 
@@ -87,12 +87,13 @@ Layer *N* is the longest chain of top-level (non-deferred) imports from a leaf m
 
 ## Late Import Inventory
 
-27 module(s) defer intra-package imports inside function bodies to avoid import cycles:
+28 module(s) defer intra-package imports inside function bodies to avoid import cycles:
 
 | Module | Late Imports |
 |---|---|
+| `__init__.py` | `mcp_server.py` |
 | `agent_runner.py` | `cli.py`, `git_ops.py`, `rlm_decompose.py`, `role_resolver.py` |
-| `cli.py` | `config_versions.py`, `initiative_runner.py`, `role_resolver.py`, `scaffold.py`, `single_agent_guard.py` |
+| `cli.py` | `config_versions.py`, `initiative_runner.py`, `mcp_server.py`, `role_resolver.py`, `scaffold.py`, `single_agent_guard.py` |
 | `db.py` | `config.py`, `output.py`, `prompts.py`, `tasks.py` |
 | `dispatch.py` | `flows.py`, `initiative.py`, `scaffold.py` |
 | `embeddings.py` | `db.py`, `graph.py` |
@@ -125,14 +126,14 @@ How many other `equipa` modules each module imports.
 
 | Module | Top-level | Late | Total |
 |---|---:|---:|---:|
-| `__init__.py` | 7 | 0 | **7** |
+| `__init__.py` | 6 | 1 | **7** |
 | `__main__.py` | 1 | 0 | **1** |
 | `abort_controller.py` | 0 | 0 | **0** |
 | `agent_runner.py` | 12 | 4 | **16** |
 | `bash_security.py` | 0 | 0 | **0** |
 | `checkpoints.py` | 1 | 0 | **1** |
 | `classifier.py` | 0 | 0 | **0** |
-| `cli.py` | 24 | 5 | **29** |
+| `cli.py` | 23 | 6 | **29** |
 | `config.py` | 1 | 0 | **1** |
 | `config_versions.py` | 2 | 0 | **2** |
 | `constants.py` | 0 | 0 | **0** |

--- a/equipa/__init__.py
+++ b/equipa/__init__.py
@@ -31,7 +31,6 @@ from equipa.loops import (
     run_security_review,
 )
 from equipa.manager import run_manager_loop
-from equipa.mcp_server import run_server
 from equipa.monitoring import LoopDetector
 from equipa.prompts import PromptResult
 
@@ -56,3 +55,24 @@ __all__ = [
     "PromptResult",
     "LoopDetector",
 ]
+
+
+def __getattr__(name: str):
+    """Resolve ``run_server`` lazily (PEP 562).
+
+    ``equipa.mcp_server`` is both a submodule and an entry point executed as
+    ``python -m equipa.mcp_server``. Importing it eagerly here meant runpy loaded
+    it twice — once as ``equipa.mcp_server`` while importing this package, then
+    again as ``__main__`` — which emitted a RuntimeWarning on every server start
+    and left two copies of the module's state (including the rate-limit buckets)
+    in memory.
+
+    Deferring the import removes the duplication while keeping ``run_server`` in
+    ``__all__`` and importable as ``from equipa import run_server``, so the
+    public surface is unchanged.
+    """
+    if name == "run_server":
+        from equipa.mcp_server import run_server
+
+        return run_server
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/equipa/cli.py
+++ b/equipa/cli.py
@@ -61,7 +61,6 @@ from equipa.loops import (
     run_security_review,
 )
 from equipa.manager import run_manager_loop
-from equipa.mcp_server import run_server
 from equipa.monitoring import calculate_dynamic_budget
 from equipa.output import (
     log,
@@ -673,7 +672,16 @@ def _auto_snapshot_dispatch(
 
 
 async def run_mode_mcp_server(args: argparse.Namespace) -> None:
-    """Run as MCP server (JSON-RPC over stdio)."""
+    """Run as MCP server (JSON-RPC over stdio).
+
+    The import is function-local rather than module-level so that importing
+    ``equipa`` (which imports this module) does not pull in ``equipa.mcp_server``.
+    That import made ``python -m equipa.mcp_server`` load the module twice —
+    once as ``equipa.mcp_server`` via the package, then again as ``__main__``
+    via runpy — which emitted a RuntimeWarning on every server start.
+    """
+    from equipa.mcp_server import run_server
+
     run_server()
 
 

--- a/equipa/mcp_server.py
+++ b/equipa/mcp_server.py
@@ -6,7 +6,7 @@ Uses ONLY Python stdlib (json, sys, subprocess) — no external dependencies.
 Implements:
 - JSON-RPC 2.0 protocol over stdio
 - MCP initialization handshake
-- 8 tools: dispatch, task_status, task_create, lessons, agent_logs, project_context, session_notes, session_note_add
+- 9 tools: dispatch, task_status, task_create, lessons, agent_logs, project_context, session_notes, session_note_add, lesson_add
 
 Hardening (SECURITY-REVIEW-1728, task 2452):
 - MCP-01: equipa_dispatch requires EQUIPA_MCP_TOKEN auth, is rate-limited
@@ -19,6 +19,11 @@ Hardening (SECURITY-REVIEW-1728, task 2452):
   lesson_sanitizer.sanitize_session_note (injection-strip + generous length
   policy, no silent truncation) so session notes cannot be written unsanitized
   through the semantic write path.
+- MCP-05: equipa_lesson_add is the write counterpart to equipa_lessons — same
+  auth + rate-limit + (optional) project validation, and sanitizes the lesson
+  body through lesson_sanitizer.sanitize_lesson_content and the short metadata
+  fields through sanitize_error_signature, closing the identical advisory-only
+  gap for the lessons_learned table.
 
 Stderr is used for logging only. Stdout is reserved for JSON-RPC messages.
 
@@ -74,6 +79,8 @@ TASK_CREATE_RATE_CAPACITY = 100
 TASK_CREATE_RATE_REFILL_SECONDS = 3600
 SESSION_NOTE_RATE_CAPACITY = 100
 SESSION_NOTE_RATE_REFILL_SECONDS = 3600
+LESSON_ADD_RATE_CAPACITY = 100
+LESSON_ADD_RATE_REFILL_SECONDS = 3600
 
 # Project statuses allowed as task_create targets.
 ALLOWED_PROJECT_STATUSES = {"active", "planning"}
@@ -188,6 +195,7 @@ class _TokenBucket:
 _DISPATCH_BUCKET = _TokenBucket(DISPATCH_RATE_CAPACITY, DISPATCH_RATE_REFILL_SECONDS)
 _TASK_CREATE_BUCKET = _TokenBucket(TASK_CREATE_RATE_CAPACITY, TASK_CREATE_RATE_REFILL_SECONDS)
 _SESSION_NOTE_BUCKET = _TokenBucket(SESSION_NOTE_RATE_CAPACITY, SESSION_NOTE_RATE_REFILL_SECONDS)
+_LESSON_ADD_BUCKET = _TokenBucket(LESSON_ADD_RATE_CAPACITY, LESSON_ADD_RATE_REFILL_SECONDS)
 
 
 def _expected_token() -> str | None:
@@ -751,6 +759,110 @@ def _handle_equipa_session_note_add(args: dict) -> dict:
         }
 
 
+def _handle_equipa_lesson_add(args: dict) -> dict:
+    """Write a lesson to lessons_learned, sanitizing all text fields.
+
+    The *write* counterpart to equipa_lessons. Like equipa_session_note_add it
+    exists so a lesson can be persisted through the sanctioned MCP interface with
+    sanitization applied *at the boundary*, rather than relying on the caller to
+    run lesson_sanitizer first. The lesson body is passed through
+    sanitize_lesson_content (500-char lesson cap, injection-strip, loud on
+    truncation) and the short metadata fields through sanitize_error_signature.
+
+    Args:
+        auth_token (str): Required. Must match EQUIPA_MCP_TOKEN env var.
+        lesson (str): Required. The lesson text (sanitized; capped at the lesson
+            length limit).
+        project_id (int, optional): Scope to a project — must exist and be
+            {active, planning}. Omit for a global lesson (project_id NULL).
+        role (str, optional): Agent role the lesson applies to.
+        error_type (str, optional): Error category.
+        error_signature (str, optional): Short error signature.
+        source (str, optional): Provenance tag (default "manual-mcp").
+
+    Returns:
+        dict: {"lesson_id": int, "status": "created", ...} or {"error": ...}.
+    """
+    ok, err = _check_auth(args)
+    if not ok:
+        return err
+
+    token = _expected_token() or "anonymous"
+    allowed, retry_after = _LESSON_ADD_BUCKET.try_consume(token)
+    if not allowed:
+        return {
+            "error": "Rate limit exceeded for equipa_lesson_add",
+            "retry_after_seconds": round(retry_after, 2),
+            "limit": f"{LESSON_ADD_RATE_CAPACITY}/{LESSON_ADD_RATE_REFILL_SECONDS}s",
+        }
+
+    # project_id is optional (lessons may be global). When present it is validated
+    # exactly like the other write tools; when absent the lesson is stored global.
+    project_id = args.get("project_id")
+    if project_id is not None:
+        if not isinstance(project_id, int) or project_id <= 0:
+            return {"error": "project_id must be a positive integer when provided"}
+        allowlist = _project_id_allowlist()
+        if allowlist is not None and project_id not in allowlist:
+            return {
+                "error": f"project_id {project_id} not in EQUIPA_MCP_PROJECT_IDS allowlist",
+            }
+
+    # Sanitize at the boundary. Imported lazily (repo-root module) so an import
+    # failure degrades to a length-capping fallback rather than downing the server.
+    try:
+        from lesson_sanitizer import sanitize_lesson_content, sanitize_error_signature
+    except Exception:  # pragma: no cover - fallback if sanitizer unavailable
+        def sanitize_lesson_content(text: Any, *a: Any, **k: Any) -> str:
+            return ("" if not text else str(text))[:500]
+
+        def sanitize_error_signature(text: Any) -> str:
+            return ("" if not text else str(text))[:200]
+
+    lesson = sanitize_lesson_content(args.get("lesson", ""))
+    if not lesson:
+        return {"error": "lesson is required (non-empty after sanitization)"}
+
+    role = sanitize_error_signature(args.get("role", "")) or None
+    error_type = sanitize_error_signature(args.get("error_type", "")) or None
+    error_signature = sanitize_error_signature(args.get("error_signature", "")) or None
+    source = sanitize_error_signature(args.get("source", "")) or "manual-mcp"
+
+    with _db_conn(write=True) as conn:
+        if project_id is not None:
+            proj = conn.execute(
+                "SELECT id, status FROM projects WHERE id = ?",
+                (project_id,),
+            ).fetchone()
+            if proj is None:
+                return {"error": f"project_id {project_id} does not exist"}
+            status = (proj["status"] or "").lower()
+            if status not in ALLOWED_PROJECT_STATUSES:
+                return {
+                    "error": (
+                        f"project_id {project_id} has status {status!r}; "
+                        f"expected one of {sorted(ALLOWED_PROJECT_STATUSES)}"
+                    ),
+                }
+
+        cursor = conn.execute(
+            """
+            INSERT INTO lessons_learned
+                (project_id, role, error_type, error_signature, lesson, source)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (project_id, role, error_type, error_signature, lesson, source),
+        )
+        lesson_id = cursor.lastrowid
+
+        return {
+            "lesson_id": lesson_id,
+            "status": "created",
+            "project_id": project_id,
+            "lesson_chars": len(lesson),
+        }
+
+
 # --- Tool Registry ---
 
 TOOLS = {
@@ -853,6 +965,23 @@ TOOLS = {
             "required": ["auth_token", "project_id", "summary"],
         },
         "handler": _handle_equipa_session_note_add,
+    },
+    "equipa_lesson_add": {
+        "description": "Write a lesson to lessons_learned with mandatory sanitization (requires auth_token)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "auth_token": {"type": "string", "description": "Server token (matches EQUIPA_MCP_TOKEN)"},
+                "lesson": {"type": "string", "description": "Lesson text (sanitized; capped at the lesson length limit)"},
+                "project_id": {"type": "integer", "description": "Optional project scope (must exist, status active/planning); omit for a global lesson"},
+                "role": {"type": "string", "description": "Agent role the lesson applies to (sanitized)"},
+                "error_type": {"type": "string", "description": "Error category (sanitized)"},
+                "error_signature": {"type": "string", "description": "Short error signature (sanitized)"},
+                "source": {"type": "string", "description": "Provenance tag (default 'manual-mcp')"},
+            },
+            "required": ["auth_token", "lesson"],
+        },
+        "handler": _handle_equipa_lesson_add,
     },
 }
 

--- a/equipa/mcp_server.py
+++ b/equipa/mcp_server.py
@@ -6,7 +6,7 @@ Uses ONLY Python stdlib (json, sys, subprocess) — no external dependencies.
 Implements:
 - JSON-RPC 2.0 protocol over stdio
 - MCP initialization handshake
-- 9 tools: dispatch, task_status, task_create, lessons, agent_logs, project_context, session_notes, session_note_add, lesson_add
+- 10 tools: dispatch, task_status, task_create, lessons, agent_logs, project_context, session_notes, session_note_add, lesson_add, decision_add
 
 Hardening (SECURITY-REVIEW-1728, task 2452):
 - MCP-01: equipa_dispatch requires EQUIPA_MCP_TOKEN auth, is rate-limited
@@ -24,6 +24,12 @@ Hardening (SECURITY-REVIEW-1728, task 2452):
   body through lesson_sanitizer.sanitize_lesson_content and the short metadata
   fields through sanitize_error_signature, closing the identical advisory-only
   gap for the lessons_learned table.
+- MCP-06: equipa_decision_add closes the same gap for the decisions table —
+  auth + rate-limit + project validation, plus decision_type/status vocabulary
+  checks (the table carries no CHECK constraints). Field caps are asymmetric by
+  measurement: topic/rationale/alternatives use sanitize_decision, while the
+  narrative decision body uses sanitize_decision_body, because decision bodies
+  accrete amendments and the rationale cap would silently destroy them.
 
 Stderr is used for logging only. Stdout is reserved for JSON-RPC messages.
 
@@ -81,9 +87,30 @@ SESSION_NOTE_RATE_CAPACITY = 100
 SESSION_NOTE_RATE_REFILL_SECONDS = 3600
 LESSON_ADD_RATE_CAPACITY = 100
 LESSON_ADD_RATE_REFILL_SECONDS = 3600
+DECISION_ADD_RATE_CAPACITY = 100
+DECISION_ADD_RATE_REFILL_SECONDS = 3600
 
 # Project statuses allowed as task_create targets.
 ALLOWED_PROJECT_STATUSES = {"active", "planning"}
+
+# decision_type / status vocabularies accepted by equipa_decision_add.
+#
+# The decisions table carries NO CHECK constraints, so these columns have drifted
+# in practice. Each set below is the UNION of the documented vocabulary and every
+# value already present in the table — deliberately permissive, because a stricter
+# allowlist would start rejecting values the system has been writing for months.
+# Note for maintainers: "architectural" and "architecture" are both in use and are
+# almost certainly the same category; deduplicating them is a data-hygiene change,
+# not a change this write-path should make silently.
+ALLOWED_DECISION_TYPES = {
+    "architectural", "architecture", "design", "docs-architecture", "general",
+    "ip_finding", "packaging", "regulatory_finding", "resolution",
+    "security_finding", "strategy", "technical", "trade_off",
+}
+ALLOWED_DECISION_STATUSES = {
+    "accepted", "active", "decided", "failed_resolution", "open", "resolved",
+    "superseded", "wont_fix",
+}
 
 # Role + model allowlists for equipa_dispatch. Built from orchestrator constants
 # where possible; the fallbacks ensure the MCP server still refuses unknown
@@ -196,6 +223,7 @@ _DISPATCH_BUCKET = _TokenBucket(DISPATCH_RATE_CAPACITY, DISPATCH_RATE_REFILL_SEC
 _TASK_CREATE_BUCKET = _TokenBucket(TASK_CREATE_RATE_CAPACITY, TASK_CREATE_RATE_REFILL_SECONDS)
 _SESSION_NOTE_BUCKET = _TokenBucket(SESSION_NOTE_RATE_CAPACITY, SESSION_NOTE_RATE_REFILL_SECONDS)
 _LESSON_ADD_BUCKET = _TokenBucket(LESSON_ADD_RATE_CAPACITY, LESSON_ADD_RATE_REFILL_SECONDS)
+_DECISION_ADD_BUCKET = _TokenBucket(DECISION_ADD_RATE_CAPACITY, DECISION_ADD_RATE_REFILL_SECONDS)
 
 
 def _expected_token() -> str | None:
@@ -863,6 +891,141 @@ def _handle_equipa_lesson_add(args: dict) -> dict:
         }
 
 
+def _handle_equipa_decision_add(args: dict) -> dict:
+    """Write an architectural/product decision to TheForge, sanitizing all text.
+
+    The *write* counterpart to the decisions half of equipa_project_context, and
+    the third sanitizing write-tool alongside equipa_session_note_add and
+    equipa_lesson_add. It closes the same advisory-only gap for the decisions
+    table: without it, decisions can only be written by raw SQL through a generic
+    database adapter, with no auth, no rate limit, no project validation and no
+    sanitization at the boundary.
+
+    Field caps are asymmetric by design and by measurement. topic / rationale /
+    alternatives_considered use sanitize_decision (MAX_DECISION_LENGTH — the
+    constant's own comment reads "decision rationales"), while the narrative
+    ``decision`` body uses sanitize_decision_body (MAX_SESSION_NOTE_LENGTH),
+    because decision bodies accrete amendments over time and the rationale cap
+    would silently destroy them. See lesson_sanitizer for the measurements.
+
+    Args:
+        auth_token (str): Required. Must match EQUIPA_MCP_TOKEN env var.
+        project_id (int): Required. Must exist and be {active, planning}.
+        topic (str): Required. What the decision is about.
+        decision (str): Required. What was decided.
+        rationale (str, optional): Why.
+        alternatives_considered (str, optional): What else was weighed.
+        decision_type (str, optional): Category (default "general").
+        status (str, optional): Lifecycle state (default "open").
+
+    Returns:
+        dict: {"decision_id": int, "status": "created", ...} or {"error": ...}.
+    """
+    ok, err = _check_auth(args)
+    if not ok:
+        return err
+
+    token = _expected_token() or "anonymous"
+    allowed, retry_after = _DECISION_ADD_BUCKET.try_consume(token)
+    if not allowed:
+        return {
+            "error": "Rate limit exceeded for equipa_decision_add",
+            "retry_after_seconds": round(retry_after, 2),
+            "limit": f"{DECISION_ADD_RATE_CAPACITY}/{DECISION_ADD_RATE_REFILL_SECONDS}s",
+        }
+
+    project_id = args.get("project_id")
+    if not isinstance(project_id, int) or project_id <= 0:
+        return {"error": "project_id must be a positive integer"}
+
+    allowlist = _project_id_allowlist()
+    if allowlist is not None and project_id not in allowlist:
+        return {
+            "error": f"project_id {project_id} not in EQUIPA_MCP_PROJECT_IDS allowlist",
+        }
+
+    # Sanitize at the boundary. Imported lazily (repo-root module) so an import
+    # failure degrades to a length-capping fallback rather than downing the server.
+    try:
+        from lesson_sanitizer import sanitize_decision, sanitize_decision_body
+    except Exception:  # pragma: no cover - fallback if sanitizer unavailable
+        def sanitize_decision(text: Any) -> str:
+            return ("" if not text else str(text))[:8_000]
+
+        def sanitize_decision_body(text: Any) -> str:
+            return ("" if not text else str(text))[:50_000]
+
+    topic = sanitize_decision(args.get("topic", ""))
+    decision = sanitize_decision_body(args.get("decision", ""))
+    rationale = sanitize_decision(args.get("rationale", "")) or None
+    alternatives = sanitize_decision(args.get("alternatives_considered", "")) or None
+
+    if not topic:
+        return {"error": "topic is required (non-empty after sanitization)"}
+    if not decision:
+        return {"error": "decision is required (non-empty after sanitization)"}
+
+    decision_type = (args.get("decision_type") or "general").strip().lower()
+    if decision_type not in ALLOWED_DECISION_TYPES:
+        return {
+            "error": (
+                f"decision_type {decision_type!r} not recognised; "
+                f"expected one of {sorted(ALLOWED_DECISION_TYPES)}"
+            ),
+        }
+
+    status = (args.get("status") or "open").strip().lower()
+    if status not in ALLOWED_DECISION_STATUSES:
+        return {
+            "error": (
+                f"status {status!r} not recognised; "
+                f"expected one of {sorted(ALLOWED_DECISION_STATUSES)}"
+            ),
+        }
+
+    with _db_conn(write=True) as conn:
+        proj = conn.execute(
+            "SELECT id, status FROM projects WHERE id = ?",
+            (project_id,),
+        ).fetchone()
+        if proj is None:
+            return {"error": f"project_id {project_id} does not exist"}
+        proj_status = (proj["status"] or "").lower()
+        if proj_status not in ALLOWED_PROJECT_STATUSES:
+            return {
+                "error": (
+                    f"project_id {project_id} has status {proj_status!r}; "
+                    f"expected one of {sorted(ALLOWED_PROJECT_STATUSES)}"
+                ),
+            }
+
+        # The timestamp column is deliberately omitted so its DEFAULT
+        # CURRENT_TIMESTAMP applies. Production names it ``decided_at``; the test
+        # fixture in tests/test_mcp_server.py names it ``created_at``. Letting the
+        # default fire keeps this INSERT portable across both rather than binding
+        # the write path to one schema's column name.
+        cursor = conn.execute(
+            """
+            INSERT INTO decisions
+                (project_id, topic, decision, rationale, alternatives_considered,
+                 decision_type, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (project_id, topic, decision, rationale, alternatives,
+             decision_type, status),
+        )
+        decision_id = cursor.lastrowid
+
+        return {
+            "decision_id": decision_id,
+            "status": "created",
+            "project_id": project_id,
+            "decision_type": decision_type,
+            "decision_status": status,
+            "decision_chars": len(decision),
+        }
+
+
 # --- Tool Registry ---
 
 TOOLS = {
@@ -982,6 +1145,24 @@ TOOLS = {
             "required": ["auth_token", "lesson"],
         },
         "handler": _handle_equipa_lesson_add,
+    },
+    "equipa_decision_add": {
+        "description": "Write a decision to TheForge with mandatory sanitization (requires auth_token)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "auth_token": {"type": "string", "description": "Server token (matches EQUIPA_MCP_TOKEN)"},
+                "project_id": {"type": "integer", "description": "Project ID (must exist, status active/planning)"},
+                "topic": {"type": "string", "description": "What the decision is about (sanitized)"},
+                "decision": {"type": "string", "description": "What was decided (sanitized; narrative, up to ~50k chars)"},
+                "rationale": {"type": "string", "description": "Why (sanitized)"},
+                "alternatives_considered": {"type": "string", "description": "What else was weighed (sanitized)"},
+                "decision_type": {"type": "string", "description": f"Category (default 'general'); one of {sorted(ALLOWED_DECISION_TYPES)}", "default": "general"},
+                "status": {"type": "string", "description": f"Lifecycle state (default 'open'); one of {sorted(ALLOWED_DECISION_STATUSES)}", "default": "open"},
+            },
+            "required": ["auth_token", "project_id", "topic", "decision"],
+        },
+        "handler": _handle_equipa_decision_add,
     },
 }
 

--- a/equipa/mcp_server.py
+++ b/equipa/mcp_server.py
@@ -6,7 +6,7 @@ Uses ONLY Python stdlib (json, sys, subprocess) — no external dependencies.
 Implements:
 - JSON-RPC 2.0 protocol over stdio
 - MCP initialization handshake
-- 7 tools: dispatch, task_status, task_create, lessons, agent_logs, project_context, session_notes
+- 8 tools: dispatch, task_status, task_create, lessons, agent_logs, project_context, session_notes, session_note_add
 
 Hardening (SECURITY-REVIEW-1728, task 2452):
 - MCP-01: equipa_dispatch requires EQUIPA_MCP_TOKEN auth, is rate-limited
@@ -14,6 +14,11 @@ Hardening (SECURITY-REVIEW-1728, task 2452):
 - MCP-02: equipa_task_create validates project existence + status, caps
   description size, is rate-limited, and honours EQUIPA_MCP_PROJECT_IDS allowlist.
 - MCP-03: All query handlers clamp caller-supplied ``limit`` to MAX_QUERY_LIMIT.
+- MCP-04: equipa_session_note_add requires auth, validates project existence +
+  status, is rate-limited, and sanitizes summary/next_steps/key_points through
+  lesson_sanitizer.sanitize_session_note (injection-strip + generous length
+  policy, no silent truncation) so session notes cannot be written unsanitized
+  through the semantic write path.
 
 Stderr is used for logging only. Stdout is reserved for JSON-RPC messages.
 
@@ -67,6 +72,8 @@ DISPATCH_RATE_CAPACITY = 10          # 10 dispatches
 DISPATCH_RATE_REFILL_SECONDS = 3600  # ...per hour per token
 TASK_CREATE_RATE_CAPACITY = 100
 TASK_CREATE_RATE_REFILL_SECONDS = 3600
+SESSION_NOTE_RATE_CAPACITY = 100
+SESSION_NOTE_RATE_REFILL_SECONDS = 3600
 
 # Project statuses allowed as task_create targets.
 ALLOWED_PROJECT_STATUSES = {"active", "planning"}
@@ -180,6 +187,7 @@ class _TokenBucket:
 
 _DISPATCH_BUCKET = _TokenBucket(DISPATCH_RATE_CAPACITY, DISPATCH_RATE_REFILL_SECONDS)
 _TASK_CREATE_BUCKET = _TokenBucket(TASK_CREATE_RATE_CAPACITY, TASK_CREATE_RATE_REFILL_SECONDS)
+_SESSION_NOTE_BUCKET = _TokenBucket(SESSION_NOTE_RATE_CAPACITY, SESSION_NOTE_RATE_REFILL_SECONDS)
 
 
 def _expected_token() -> str | None:
@@ -649,6 +657,100 @@ def _handle_equipa_session_notes(args: dict) -> dict:
         }
 
 
+def _handle_equipa_session_note_add(args: dict) -> dict:
+    """Write a session note to TheForge, sanitizing narrative fields.
+
+    The *write* counterpart to equipa_session_notes. It exists so a session note
+    can be persisted through the sanctioned MCP interface with the mandatory
+    sanitization applied *at the boundary*, rather than depending on the caller
+    (e.g. the forge-end skill) to remember to run lesson_sanitizer before a raw
+    write. summary/next_steps/key_points are passed through sanitize_session_note
+    (injection-strip + generous length policy, no silent truncation) before
+    insertion.
+
+    Args:
+        auth_token (str): Required. Must match EQUIPA_MCP_TOKEN env var.
+        project_id (int): Project ID — must exist and be {active, planning}.
+        summary (str): Required. What happened this session.
+        next_steps (str, optional): What to do next.
+        key_points (str, optional): Key points / highlights.
+
+    Returns:
+        dict: {"session_note_id": int, "status": "created", ...} or {"error": ...}.
+    """
+    ok, err = _check_auth(args)
+    if not ok:
+        return err
+
+    token = _expected_token() or "anonymous"
+    allowed, retry_after = _SESSION_NOTE_BUCKET.try_consume(token)
+    if not allowed:
+        return {
+            "error": "Rate limit exceeded for equipa_session_note_add",
+            "retry_after_seconds": round(retry_after, 2),
+            "limit": f"{SESSION_NOTE_RATE_CAPACITY}/{SESSION_NOTE_RATE_REFILL_SECONDS}s",
+        }
+
+    project_id = args.get("project_id")
+    if not isinstance(project_id, int) or project_id <= 0:
+        return {"error": "project_id must be a positive integer"}
+
+    allowlist = _project_id_allowlist()
+    if allowlist is not None and project_id not in allowlist:
+        return {
+            "error": f"project_id {project_id} not in EQUIPA_MCP_PROJECT_IDS allowlist",
+        }
+
+    # Sanitize narrative fields at the boundary. Imported lazily (repo-root
+    # module) so an import failure degrades to a length-capping fallback rather
+    # than taking the whole server down.
+    try:
+        from lesson_sanitizer import sanitize_session_note
+    except Exception:  # pragma: no cover - fallback if sanitizer unavailable
+        def sanitize_session_note(text: Any) -> str:
+            return ("" if not text else str(text))[:50_000]
+
+    summary = sanitize_session_note(args.get("summary", ""))
+    next_steps = sanitize_session_note(args.get("next_steps", ""))
+    key_points = sanitize_session_note(args.get("key_points", ""))
+
+    if not summary:
+        return {"error": "summary is required (non-empty after sanitization)"}
+
+    with _db_conn(write=True) as conn:
+        proj = conn.execute(
+            "SELECT id, status FROM projects WHERE id = ?",
+            (project_id,),
+        ).fetchone()
+        if proj is None:
+            return {"error": f"project_id {project_id} does not exist"}
+        status = (proj["status"] or "").lower()
+        if status not in ALLOWED_PROJECT_STATUSES:
+            return {
+                "error": (
+                    f"project_id {project_id} has status {status!r}; "
+                    f"expected one of {sorted(ALLOWED_PROJECT_STATUSES)}"
+                ),
+            }
+
+        cursor = conn.execute(
+            """
+            INSERT INTO session_notes
+                (project_id, summary, key_points, next_steps, session_date)
+            VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+            """,
+            (project_id, summary, key_points, next_steps),
+        )
+        note_id = cursor.lastrowid
+
+        return {
+            "session_note_id": note_id,
+            "status": "created",
+            "project_id": project_id,
+            "summary_chars": len(summary),
+        }
+
+
 # --- Tool Registry ---
 
 TOOLS = {
@@ -736,6 +838,21 @@ TOOLS = {
             },
         },
         "handler": _handle_equipa_session_notes,
+    },
+    "equipa_session_note_add": {
+        "description": "Write a session note to TheForge with mandatory sanitization (requires auth_token)",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "auth_token": {"type": "string", "description": "Server token (matches EQUIPA_MCP_TOKEN)"},
+                "project_id": {"type": "integer", "description": "Project ID (must exist, status active/planning)"},
+                "summary": {"type": "string", "description": "What happened this session (sanitized; up to ~50k chars)"},
+                "next_steps": {"type": "string", "description": "What to do next (sanitized)"},
+                "key_points": {"type": "string", "description": "Key points / highlights (sanitized)"},
+            },
+            "required": ["auth_token", "project_id", "summary"],
+        },
+        "handler": _handle_equipa_session_note_add,
     },
 }
 

--- a/lesson_sanitizer.py
+++ b/lesson_sanitizer.py
@@ -172,6 +172,40 @@ def sanitize_session_note(text):
                                    label="session note")
 
 
+def sanitize_decision(text):
+    """Sanitize a decision's short fields (topic / rationale / alternatives).
+
+    Uses MAX_DECISION_LENGTH, which is sized for exactly these fields — the
+    constant's own comment reads "decision rationales". Measured against a
+    636-row decisions table the longest rationale was 4,355 chars and the
+    longest alternatives_considered 1,062, so the 8,000 cap has ample headroom
+    and will not truncate real records.
+
+    For the narrative ``decision`` body itself use sanitize_decision_body();
+    this cap *would* truncate it.
+    """
+    return sanitize_lesson_content(text, max_len=MAX_DECISION_LENGTH,
+                                   label="decision field")
+
+
+def sanitize_decision_body(text):
+    """Sanitize the narrative ``decision`` body without silent loss.
+
+    Decision bodies are narrative and *accrete* — amendments, corrections and
+    superseding notes are appended to an existing record rather than replacing
+    it — so they grow well past the rationale cap. Measured against a 636-row
+    decisions table, 12 rows (1.9%) already exceed MAX_DECISION_LENGTH and the
+    longest ran 32,344 chars. Capping the body at MAX_DECISION_LENGTH would
+    therefore destroy real content, which is the same failure mode the 500-char
+    lesson cap caused for session notes (Equipa task #100027).
+
+    Uses MAX_SESSION_NOTE_LENGTH: the body is narrative content of the same
+    class as a session-note summary.
+    """
+    return sanitize_lesson_content(text, max_len=MAX_SESSION_NOTE_LENGTH,
+                                   label="decision body")
+
+
 def sanitize_error_signature(sig):
     """Sanitize an error signature before using it in lesson generation.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -228,7 +228,7 @@ def test_initialized_notification(mcp_server):
 
 
 def test_tools_list(mcp_server):
-    """Test tools/list returns all 7 tools."""
+    """Test tools/list returns all 8 tools."""
     response = _send_request(mcp_server, "tools/list", {})
 
     assert response["jsonrpc"] == "2.0"
@@ -246,6 +246,7 @@ def test_tools_list(mcp_server):
         "equipa_agent_logs",
         "equipa_project_context",
         "equipa_session_notes",
+        "equipa_session_note_add",
     }
 
     assert tool_names == expected

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -228,7 +228,7 @@ def test_initialized_notification(mcp_server):
 
 
 def test_tools_list(mcp_server):
-    """Test tools/list returns all 8 tools."""
+    """Test tools/list returns all 9 tools."""
     response = _send_request(mcp_server, "tools/list", {})
 
     assert response["jsonrpc"] == "2.0"
@@ -247,6 +247,7 @@ def test_tools_list(mcp_server):
         "equipa_project_context",
         "equipa_session_notes",
         "equipa_session_note_add",
+        "equipa_lesson_add",
     }
 
     assert tool_names == expected

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -248,6 +248,7 @@ def test_tools_list(mcp_server):
         "equipa_session_notes",
         "equipa_session_note_add",
         "equipa_lesson_add",
+        "equipa_decision_add",
     }
 
     assert tool_names == expected
@@ -789,3 +790,135 @@ def test_cli_mcp_server_flag():
     import equipa.mcp_server
     assert hasattr(equipa.mcp_server, "run_server")
     assert callable(equipa.mcp_server.run_server)
+
+
+# --- equipa_decision_add (MCP-06) ---
+
+def _decision_add(server, **overrides) -> dict:
+    """Call equipa_decision_add with sane defaults, returning the parsed payload."""
+    args = {
+        "auth_token": TEST_TOKEN,
+        "project_id": 23,
+        "topic": "Adopt the Hooper reverser",
+        "decision": "Prototype both reversal mechanisms on one circuit.",
+    }
+    args.update(overrides)
+    response = _send_request(server, "tools/call", {
+        "name": "equipa_decision_add",
+        "arguments": args,
+    })
+    return json.loads(response["result"]["content"][0]["text"])
+
+
+def test_decision_add_happy_path(mcp_server, isolated_db):
+    """A well-formed call persists a decision and reports its id."""
+    content = _decision_add(
+        mcp_server,
+        rationale="Comparative data beats proving one approach.",
+        alternatives_considered="Bench rig only.",
+        decision_type="architectural",
+        status="decided",
+    )
+
+    assert "error" not in content, content
+    assert content["status"] == "created"
+    assert content["project_id"] == 23
+    assert content["decision_type"] == "architectural"
+    assert content["decision_status"] == "decided"
+    assert isinstance(content["decision_id"], int)
+
+    conn = sqlite3.connect(str(isolated_db))
+    try:
+        row = conn.execute(
+            "SELECT project_id, topic, decision, rationale, decision_type, status "
+            "FROM decisions WHERE id = ?",
+            (content["decision_id"],),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row[0] == 23
+    assert row[1] == "Adopt the Hooper reverser"
+    assert row[4] == "architectural"
+    assert row[5] == "decided"
+
+
+def test_decision_add_defaults(mcp_server):
+    """decision_type and status default to general/open when omitted."""
+    content = _decision_add(mcp_server)
+
+    assert "error" not in content, content
+    assert content["decision_type"] == "general"
+    assert content["decision_status"] == "open"
+
+
+def test_decision_add_requires_auth(isolated_db):
+    """Without a matching token the write is refused."""
+    proc = _spawn_server(isolated_db)
+    try:
+        content = _decision_add(proc, auth_token="wrong-token")
+        assert "error" in content
+    finally:
+        _stop_server(proc)
+
+
+def test_decision_add_rejects_unknown_vocabulary(mcp_server):
+    """decision_type and status are checked against the accepted vocabularies."""
+    bad_type = _decision_add(mcp_server, decision_type="not-a-category")
+    assert "error" in bad_type
+    assert "decision_type" in bad_type["error"]
+
+    bad_status = _decision_add(mcp_server, status="not-a-status")
+    assert "error" in bad_status
+    assert "status" in bad_status["error"]
+
+
+def test_decision_add_validates_project(mcp_server):
+    """A nonexistent project_id is rejected before any insert."""
+    content = _decision_add(mcp_server, project_id=999999)
+    assert "error" in content
+    assert "does not exist" in content["error"]
+
+
+def test_decision_add_requires_topic_and_decision(mcp_server):
+    """Empty topic or decision is rejected after sanitization."""
+    assert "error" in _decision_add(mcp_server, topic="")
+    assert "error" in _decision_add(mcp_server, decision="")
+
+
+def test_decision_body_cap_exceeds_rationale_cap():
+    """The narrative body must not be capped at the rationale limit.
+
+    Decision bodies accrete amendments; measured against a 636-row production
+    table 1.9% already exceed MAX_DECISION_LENGTH, the longest at 32,344 chars.
+    Capping the body there would silently destroy real records — the failure
+    mode behind Equipa task #100027.
+    """
+    from lesson_sanitizer import (
+        MAX_DECISION_LENGTH,
+        sanitize_decision,
+        sanitize_decision_body,
+    )
+
+    # Prose, not filler. A long unbroken alphanumeric run would be removed
+    # wholesale by the base64-blob injection pattern ([A-Za-z0-9+/]{80,}), which
+    # is correct behaviour but makes "x" * N useless as a length fixture.
+    sentence = "The reverser rotates the car body through the frog. "
+    long_body = sentence * 400  # ~20.8k chars, comfortably over the 8k cap
+
+    assert len(sanitize_decision_body(long_body)) > MAX_DECISION_LENGTH
+    assert len(sanitize_decision(long_body)) == MAX_DECISION_LENGTH
+
+
+def test_sanitize_strips_base64_blobs():
+    """Long unbroken alphanumeric runs are stripped as suspected encoded payloads.
+
+    Documented because it is easy to mistake for data loss: the injection pattern
+    [A-Za-z0-9+/]{80,} removes base64-shaped blobs wholesale, and unlike the
+    length caps this removal is not logged. Ordinary prose is unaffected.
+    """
+    from lesson_sanitizer import sanitize_decision_body
+
+    assert sanitize_decision_body("A" * 200) == ""
+    assert "reverser" in sanitize_decision_body("The reverser turns the car.")


### PR DESCRIPTION
## What

Adds two sanitizing **write** tools to the semantic equipa MCP server (`equipa/mcp_server.py`), closing an advisory-only sanitization gap: the server previously exposed `session_notes` and `lessons` as **read-only**, so the only way to write either was raw `write_query`, bypassing injection-strip and the length policy entirely.

- **`equipa_session_note_add`** (MCP-04) — writes a session note; sanitizes `summary`/`next_steps`/`key_points` through `lesson_sanitizer.sanitize_session_note` (generous length policy, no silent truncation) at the boundary.
- **`equipa_lesson_add`** (MCP-05) — writes a lesson to `lessons_learned`; sanitizes the body via `sanitize_lesson_content` and short metadata (`role`/`error_type`/`error_signature`/`source`) via `sanitize_error_signature`. `project_id` optional (omit for a global lesson).

Both mirror `equipa_task_create`'s guard-rails: `EQUIPA_MCP_TOKEN` auth, per-token rate limit, project exist/status validation, and `EQUIPA_MCP_PROJECT_IDS` allowlist. Server tool count 7 → 9; `test_tools_list` updated to assert 9.

## Verification

- `py_compile` clean.
- All guard-rails (no/bad token, bad/absent `project_id`, empty body) reject **before** any DB write.
- Happy-path `lesson_add` insert strips an `IGNORE ALL PREVIOUS INSTRUCTIONS` payload while preserving the real body; test row cleaned up.
- `test_tools_list` passes.

## Notes for the maintainer

- This is the **code** for boundary enforcement. It is **not** hermetic until an installation actually points its `equipa` MCP at this semantic server instead of the generic `mcp-server-sqlite` passthrough — which can't happen cleanly until the semantic server also covers ad-hoc reads + the other narrative writes. Tracked as a follow-up (Equipa task #100076).
- The companion `/forge-end` skill change (prefer these tools over the python-sanitize-then-`write_query` flow) is intentionally **not** in this PR — it should layer on top of the still-open **PR #27** (forge-end SQL schema fix), not diverge from it.

Task #100075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Updated 2026-09-03 — refreshed to the current version

Branch fast-forwarded (`8d349e2 → 0394760`, no history rewritten) to carry the newer write-tool set this work has grown into:

- **`equipa_decision_add`** (MCP-06) added — the third sanitizing write tool, closing the same advisory-only gap for the `decisions` table (asymmetric caps: `topic`/`rationale`/`alternatives` via `sanitize_decision`, the narrative `decision` body via `sanitize_decision_body` so amendments are not truncated).
- **`fix(mcp): stop double-importing mcp_server under python -m`** — a startup fix folded in.

Server tool count is now **7 → 10**. **PR #29 (schema v13 + objectives) stacks on this branch**, so merging this first lets #29 rebase to just its own change.
