### PR TITLE
chore(gitignore): ignore DB backups and .wav artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ mcp_config.json
 *.db-journal
 *.db-wal
 *.db-shm
+# DB backups — the *.db rule above does not match these suffixes
+*.db.bak*
+*.db.backup*
+
+# Audio analysis artifacts
+*.wav
 
 # Secrets
 .env


### PR DESCRIPTION
## What

Ignore database backups and audio artifacts that the current rules miss:

- `*.db.bak*` and `*.db.backup*` — the existing `*.db` rule does not match the timestamped backup suffixes (`theforge.db.bak-*`, `theforge.db.backup-*`), so those ~7MB snapshots showed up as untracked and could be swept into a commit by a broad `git add`.
- `*.wav` — audio analysis artifacts, untracked for the same reason.

`.gitignore` only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
