### PR TITLE
fix(mcp): cap the tools/call log line so a large payload cannot deadlock the server (MCP-08)

### DIFF
--- a/equipa/MODULE_DEPENDENCY_REPORT.md
+++ b/equipa/MODULE_DEPENDENCY_REPORT.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-The `equipa/` package contains **52 Python modules** totaling **31,047 lines** of code across **11 dependency layers** (L0–L10). 27 module(s) use late (deferred) imports to break circular dependencies; there are no top-level circular imports.
+The `equipa/` package contains **52 Python modules** totaling **31,073 lines** of code across **11 dependency layers** (L0–L10). 27 module(s) use late (deferred) imports to break circular dependencies; there are no top-level circular imports.
 
 ## Module Dependency Table
 
@@ -55,7 +55,7 @@ The `equipa/` package contains **52 Python modules** totaling **31,047 lines** o
 | `sessions.py` | 335 | L2 | `checkpoints.py`, `db.py` | `agent_runner.py` | 7 |
 | `tasks.py` | 335 | L2 | `constants.py`, `db.py` | — | 8 |
 | `templates.py` | 943 | L2 | `db.py` | `constants.py`, `embeddings.py` | 8 |
-| `mcp_server.py` | 888 | L3 | `constants.py`, `tasks.py` | — | 12 |
+| `mcp_server.py` | 914 | L3 | `constants.py`, `tasks.py` | — | 13 |
 | `prompts.py` | 799 | L3 | `config.py`, `constants.py`, `lessons.py`, `parsing.py`, `security.py` | `db.py`, `git_ops.py`, `graph.py`, `initiative.py`, `role_resolver.py` | 8 |
 | `reflexion.py` | 143 | L3 | `db.py`, `lessons.py`, `output.py`, `parsing.py` | `agent_runner.py` | 4 |
 | `agent_runner.py` | 1952 | L4 | `abort_controller.py`, `bash_security.py`, `checkpoints.py`, `config.py`, `constants.py`, `db.py`, `monitoring.py`, `output.py`, `parsing.py`, `prompts.py`, `security.py`, `tasks.py` | `cli.py`, `git_ops.py`, `rlm_decompose.py`, `role_resolver.py` | 21 |
@@ -67,7 +67,7 @@ The `equipa/` package contains **52 Python modules** totaling **31,047 lines** o
 | `__init__.py` | 58 | L10 | `cli.py`, `dispatch.py`, `loops.py`, `manager.py`, `mcp_server.py`, `monitoring.py`, `prompts.py` | — | 14 |
 | `__main__.py` | 16 | L10 | `cli.py` | — | 0 |
 
-**Total:** 31,047 lines | 561 public exports
+**Total:** 31,073 lines | 562 public exports
 
 ## Modules by Layer
 

--- a/equipa/mcp_server.py
+++ b/equipa/mcp_server.py
@@ -14,8 +14,15 @@ Hardening (SECURITY-REVIEW-1728, task 2452):
 - MCP-02: equipa_task_create validates project existence + status, caps
   description size, is rate-limited, and honours EQUIPA_MCP_PROJECT_IDS allowlist.
 - MCP-03: All query handlers clamp caller-supplied ``limit`` to MAX_QUERY_LIMIT.
+- MCP-08: the tools/call log line caps the arguments it echoes. Logged verbatim,
+  a payload larger than the client's stderr pipe buffer blocked the server's
+  write and deadlocked it — the response was never sent and the client waited on
+  stdout forever. Numbered 08 to avoid colliding with MCP-04..07, claimed by
+  write-tool branches already in flight.
 
 Stderr is used for logging only. Stdout is reserved for JSON-RPC messages.
+A corollary of that split: stdout must stay drainable, and so must stderr —
+nothing written to either may be unbounded in a caller-controlled way.
 
 Copyright 2026 Forgeborn
 """
@@ -61,6 +68,13 @@ MAX_QUERY_LIMIT = 500
 
 # Maximum bytes accepted in equipa_task_create description payload (UTF-8 encoded).
 MAX_DESCRIPTION_BYTES = 32 * 1024  # 32 KB
+
+# Maximum characters of caller-supplied arguments echoed into the stderr log
+# line for a tools/call. Deliberately far below any plausible pipe buffer — the
+# smallest observed was roughly 4 KB, on Windows — because exceeding the buffer
+# does not merely spam the log, it deadlocks the server against a client that
+# is not draining stderr. See _handle_tools_call and MCP-08.
+MAX_LOG_ARGS_CHARS = 500
 
 # Token-bucket rate limits (refills continuously up to capacity).
 DISPATCH_RATE_CAPACITY = 10          # 10 dispatches
@@ -795,9 +809,21 @@ def _handle_tools_call(params: dict, request_id: int | str) -> None:
     tool_name = params.get("name")
     args = params.get("arguments", {})
 
-    # Avoid logging the auth_token verbatim.
+    # Avoid logging the auth_token verbatim, and cap the rest.
+    #
+    # The cap is not tidiness, it is liveness. This log goes to stderr, and a
+    # client that opens stderr as a pipe and does not drain it — which is what
+    # subprocess.PIPE gives you by default — leaves us only the pipe's buffer
+    # before a write blocks. Logging the arguments verbatim therefore let ANY
+    # tool call carrying more than that buffer wedge the server permanently:
+    # the write to stderr blocks, the response is never sent, and the client
+    # waits on stdout forever. See MCP-08.
     redacted = {k: ("***" if k == "auth_token" else v) for k, v in args.items()}
-    _log(f"Received tools/call: {tool_name} with args {redacted}")
+    summary = repr(redacted)
+    if len(summary) > MAX_LOG_ARGS_CHARS:
+        summary = (f"{summary[:MAX_LOG_ARGS_CHARS]}... "
+                   f"[{len(summary)} chars, truncated for logging]")
+    _log(f"Received tools/call: {tool_name} with args {summary}")
 
     if tool_name not in TOOLS:
         _send_error(request_id, -32601, f"Unknown tool: {tool_name}")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -787,3 +787,82 @@ def test_cli_mcp_server_flag():
     import equipa.mcp_server
     assert hasattr(equipa.mcp_server, "run_server")
     assert callable(equipa.mcp_server.run_server)
+
+
+# --- MCP-08: the tools/call log line must not deadlock the server -------------
+
+def _send_request_with_deadline(proc: subprocess.Popen, method: str,
+                                params: dict, timeout: float = 15.0) -> dict | None:
+    """Send a request and read one response, giving up after *timeout*.
+
+    _send_request blocks forever on a wedged server, which turns this failure
+    into a hung suite rather than a red test. Reading on a worker thread lets the
+    deadlock be observed and reported.
+    """
+    import threading
+
+    out: dict = {}
+
+    def _read() -> None:
+        try:
+            out["line"] = proc.stdout.readline()
+        except Exception as exc:  # pragma: no cover - reader died with the pipe
+            out["error"] = repr(exc)
+
+    reader = threading.Thread(target=_read, daemon=True)
+    reader.start()
+    proc.stdin.write(json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": method, "params": params,
+    }) + "\n")
+    proc.stdin.flush()
+    reader.join(timeout=timeout)
+
+    line = out.get("line")
+    return json.loads(line) if line else None
+
+
+def test_large_tool_args_do_not_deadlock_the_server(isolated_db):
+    """A payload bigger than the stderr pipe buffer must still get a response.
+
+    The server logs every tools/call to stderr. When it logged the arguments
+    verbatim, a client holding stderr as an undrained pipe — plain
+    subprocess.PIPE, which is what this harness and most MCP clients use — gave
+    the server only the pipe's buffer before its write blocked. The response was
+    then never written to stdout and the client waited forever.
+
+    The buffer size is the whole reason this hid: measured on Windows the
+    ceiling was roughly 4 KB of arguments, while a platform with a larger pipe
+    buffer swallows the same payload and the bug never shows.
+
+    Deliberately NOT using the mcp_server fixture's helper: the point is to hold
+    stderr open and unread, exactly as a real client does.
+    """
+    proc = _spawn_server(isolated_db)
+    try:
+        response = _send_request_with_deadline(proc, "tools/call", {
+            "name": "equipa_task_create",
+            "arguments": {
+                "auth_token": TEST_TOKEN,
+                "project_id": 23,
+                "title": "large but legal",
+                # comfortably past every pipe buffer we have measured, and still
+                # under MAX_DESCRIPTION_BYTES so the call is otherwise valid
+                "description": "x" * 24_000,
+            },
+        })
+        assert response is not None, (
+            "server never responded: it is blocked writing its log line to an "
+            "undrained stderr pipe"
+        )
+        assert "result" in response, response
+    finally:
+        _stop_server(proc)
+
+
+def test_tool_call_log_line_is_capped():
+    """The log line itself is bounded, whatever the caller sends."""
+    from equipa.mcp_server import MAX_LOG_ARGS_CHARS
+
+    assert MAX_LOG_ARGS_CHARS < 4_000, (
+        "cap must stay well under the smallest observed pipe buffer (~4 KB)"
+    )


### PR DESCRIPTION
Independent of #28/#29/#31 — the log line predates the write tools, so this branches off `main`.

## The failure

`_handle_tools_call` logs the caller's arguments verbatim to stderr. Stderr is a pipe the **client** owns, and a client that opens it with `subprocess.PIPE` and does not drain it — the default, and what this repo's own test harness does — leaves the server only the pipe's buffer before a write blocks.

So any `tools/call` carrying more arguments than that buffer wedges the server **permanently**: the write to stderr blocks, the JSON-RPC response is never written to stdout, and the client waits on stdout forever. No error, no exit, no timeout. The trigger is a large-but-entirely-legal request.

## Measurements

Verified as a *pipe* problem rather than a *payload* problem by sending the identical request twice — once with stderr piped and undrained, once with stderr discarded:

```
stderr=PIPE, never drained   payload=  1000  RESPONDED  (0.5s)
stderr=DEVNULL               payload=  1000  RESPONDED  (0.3s)
stderr=PIPE, never drained   payload= 32769  HUNG       (10.3s, killed)
stderr=DEVNULL               payload= 32769  RESPONDED  (0.4s)
```

Bisected threshold on Windows: responds up to ~3,750 chars of arguments, hangs from ~4,000.

Not confined to `equipa_task_create` — on the write-tool branches, `equipa_session_note_add`, `equipa_decision_add` and `equipa_lesson_add` all hang identically at 12 KB. That is worth flagging because `equipa_session_note_add` documents summaries "up to ~50k chars": the advertised capacity is an order of magnitude past the deadlock threshold.

## Why it has not been seen

The buffer size is the whole mechanism. A platform with a larger pipe buffer swallows the same payload and nothing shows.

That also explains `tests/test_mcp_server.py::test_task_create_rejects_oversize_description`, which hangs on Windows and evidently does not in CI — its 32 KB description is a payload no small-buffer client survives. **That test passes on Windows for the first time with this change.**

## The fix

Cap the arguments echoed into the log at `MAX_LOG_ARGS_CHARS = 500`, far below any buffer measured, and report the true length so the truncation is visible rather than silent.

The docstring's "stderr is for logging, stdout for JSON-RPC" note gains its corollary: both must stay drainable, so nothing written to either may be unbounded in a caller-controlled way.

## Tests

`test_large_tool_args_do_not_deadlock_the_server` holds stderr open and unread — deliberately not using the fixture helper, since the point is to behave like a real client — and sends a 24 KB legal description. It reads on a worker thread with a deadline, because the failure mode is precisely that a plain blocking read never returns, which would hang the suite rather than fail it.

Verified **red before the fix** with the intended message:

```
AssertionError: server never responded: it is blocked writing its log line to an undrained stderr pipe
```

and green after. Plus `test_tool_call_log_line_is_capped`, guarding that the cap stays under the smallest observed buffer.

`35 passed`.

## Numbering

Labelled MCP-08 to avoid colliding with MCP-04..07, claimed by the write-tool branches in flight (#28, #29, #31). The header list will read 01–03, 08 until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)